### PR TITLE
feat: return Option from queries

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node-runtime"
-version = "1.0.0"
+version = "0.22.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/runtime/src/attestation/mod.rs
+++ b/runtime/src/attestation/mod.rs
@@ -199,7 +199,7 @@ impl<T: Trait> Module<T> {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Attestation {
-		/// Attestations: claim-hash -> [(ctype-hash, account, delegation-id?, revoked)]
+		/// Attestations: claim-hash -> (ctype-hash, account, delegation-id?, revoked)?
 		Attestations get(attestations): map T::Hash => Option<(T::Hash,T::AccountId,Option<T::DelegationNodeId>,bool)>;
 		/// DelegatedAttestations: delegation-id -> [claim-hash]
 		DelegatedAttestations get(delegated_attestations): map T::DelegationNodeId => Vec<T::Hash>;

--- a/runtime/src/attestation/mod.rs
+++ b/runtime/src/attestation/mod.rs
@@ -16,7 +16,6 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-
 //! Attestation: Handles attestations on chain,
 //! adding and revoking attestations.
 
@@ -24,10 +23,13 @@
 #[cfg(test)]
 mod tests;
 
-use rstd::result;
-use rstd::prelude::*;
-use support::{dispatch::Result, StorageMap, decl_module, decl_storage, decl_event};
-use {system, super::delegation, super::ctype, super::error, system::ensure_signed};
+use super::{ctype, delegation, error};
+use rstd::{
+	prelude::{Clone, PartialEq, Vec},
+	result,
+};
+use support::{decl_event, decl_module, decl_storage, dispatch::Result, StorageMap};
+use system::{self, ensure_signed};
 
 /// The attestation trait
 pub trait Trait: system::Trait + delegation::Trait + error::Trait {
@@ -37,7 +39,7 @@ pub trait Trait: system::Trait + delegation::Trait + error::Trait {
 
 decl_event!(
 	/// Events for attestations
-	pub enum Event<T> where <T as system::Trait>::AccountId, <T as system::Trait>::Hash, 
+	pub enum Event<T> where <T as system::Trait>::AccountId, <T as system::Trait>::Hash,
 			<T as delegation::Trait>::DelegationNodeId {
 		/// An attestation has been added
 		AttestationCreated(AccountId, Hash, Hash, Option<DelegationNodeId>),
@@ -64,7 +66,7 @@ decl_module! {
 			if !<ctype::CTYPEs<T>>::exists(ctype_hash) {
 				return Self::error(<ctype::Module<T>>::ERROR_CTYPE_NOT_FOUND);
 			}
-			
+
 			match delegation_id {
 				// has a delegation
 				Some(d) => {
@@ -115,7 +117,7 @@ decl_module! {
 			}
 
 			// deposit event that attestation has beed added
-			Self::deposit_event(RawEvent::AttestationCreated(sender.clone(), claim_hash.clone(), 
+			Self::deposit_event(RawEvent::AttestationCreated(sender.clone(), claim_hash.clone(),
 					ctype_hash.clone(), delegation_id.clone()));
 			Ok(())
 		}
@@ -131,7 +133,7 @@ decl_module! {
 			if !<Attestations<T>>::exists(claim_hash.clone()) {
 				return Self::error(Self::ERROR_ATTESTATION_NOT_FOUND);
 			}
-			
+
 			// lookup attestation
 			let mut existing_attestation = <Attestations<T>>::get(claim_hash.clone())
 				.ok_or(Self::error(Self::ERROR_ATTESTATION_NOT_FOUND).err().unwrap())?;
@@ -150,7 +152,7 @@ decl_module! {
 					}
 				}
 			}
-			
+
 			// check if already revoked
 			if existing_attestation.3 {
 				return Self::error(Self::ERROR_ALREADY_REVOKED);
@@ -170,25 +172,27 @@ decl_module! {
 
 /// Implementation of further module constants and functions for attestations
 impl<T: Trait> Module<T> {
-
 	/// Error types for errors in attestation module
-    const ERROR_BASE: u16 = 2000;
-    const ERROR_ALREADY_ATTESTED : error::ErrorType = (Self::ERROR_BASE + 1, "already attested");
-    const ERROR_ALREADY_REVOKED : error::ErrorType = (Self::ERROR_BASE + 2, "already revoked");
-    const ERROR_ATTESTATION_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 3, "attestation not found");
-    const ERROR_DELEGATION_REVOKED : error::ErrorType = (Self::ERROR_BASE + 4, "delegation revoked");
-    const ERROR_NOT_DELEGATED_TO_ATTESTER : error::ErrorType = (Self::ERROR_BASE + 5, "not delegated to attester");
-    const ERROR_DELEGATION_NOT_AUTHORIZED_TO_ATTEST : error::ErrorType = (Self::ERROR_BASE + 6, "delegation not authorized to attest");
-    const ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING : error::ErrorType = (Self::ERROR_BASE + 7, "CTYPE of delegation does not match");
-    const ERROR_NOT_PERMITTED_TO_REVOKE_ATTESTATION : error::ErrorType = (Self::ERROR_BASE + 8, "not permitted to revoke attestation");
-	
+	const ERROR_BASE: u16 = 2000;
+	const ERROR_ALREADY_ATTESTED: error::ErrorType = (Self::ERROR_BASE + 1, "already attested");
+	const ERROR_ALREADY_REVOKED: error::ErrorType = (Self::ERROR_BASE + 2, "already revoked");
+	const ERROR_ATTESTATION_NOT_FOUND: error::ErrorType = (Self::ERROR_BASE + 3, "attestation not found");
+	const ERROR_DELEGATION_REVOKED: error::ErrorType = (Self::ERROR_BASE + 4, "delegation revoked");
+	const ERROR_NOT_DELEGATED_TO_ATTESTER: error::ErrorType = (Self::ERROR_BASE + 5, "not delegated to attester");
+	const ERROR_DELEGATION_NOT_AUTHORIZED_TO_ATTEST: error::ErrorType = (Self::ERROR_BASE + 6, "delegation not authorized to attest");
+	const ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING: error::ErrorType = (Self::ERROR_BASE + 7, "CTYPE of delegation does not match");
+	const ERROR_NOT_PERMITTED_TO_REVOKE_ATTESTATION: error::ErrorType = (Self::ERROR_BASE + 8, "not permitted to revoke attestation");
+
 	/// Create an error using the error module
-    pub fn error(error_type: error::ErrorType) -> Result {
-        return <error::Module<T>>::error(error_type);
-    }
-	
+	pub fn error(error_type: error::ErrorType) -> Result {
+		return <error::Module<T>>::error(error_type);
+	}
+
 	/// Check delegation hierarchy using the delegation module
-    fn is_delegating(account: &T::AccountId, delegation: &T::DelegationNodeId) -> result::Result<bool, &'static str> {
+	fn is_delegating(
+		account: &T::AccountId,
+		delegation: &T::DelegationNodeId,
+	) -> result::Result<bool, &'static str> {
 		<delegation::Module<T>>::is_delegating(account, delegation)
 	}
 }

--- a/runtime/src/attestation/mod.rs
+++ b/runtime/src/attestation/mod.rs
@@ -72,7 +72,8 @@ decl_module! {
 					if !<delegation::Delegations<T>>::exists(d.clone()) {
 						return Self::error(<delegation::Module<T>>::ERROR_DELEGATION_NOT_FOUND);
 					}
-					let delegation = <delegation::Delegations<T>>::get(d.clone()).ok_or(<delegation::Module<T>>::ERROR_DELEGATION_NOT_FOUND.1)?;
+					let delegation = <delegation::Delegations<T>>::get(d.clone())
+						.ok_or(Self::error(<delegation::Module<T>>::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 					if delegation.4 {
 						// delegation has been revoked
 						return Self::error(Self::ERROR_DELEGATION_REVOKED);
@@ -84,7 +85,8 @@ decl_module! {
 						return Self::error(Self::ERROR_DELEGATION_NOT_AUTHORIZED_TO_ATTEST);
 					} else {
 						// check if CTYPE of the delegation is matching the CTYPE of the attestation
-						let root = <delegation::Root<T>>::get(delegation.0.clone()).ok_or(<delegation::Module<T>>::ERROR_ROOT_NOT_FOUND.1)?;
+						let root = <delegation::Root<T>>::get(delegation.0.clone())
+							.ok_or(Self::error(<delegation::Module<T>>::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 						if !root.0.eq(&ctype_hash) {
 							return Self::error(Self::ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING);
 						}
@@ -131,7 +133,8 @@ decl_module! {
 			}
 			
 			// lookup attestation
-			let mut existing_attestation = <Attestations<T>>::get(claim_hash.clone()).ok_or(Self::ERROR_ATTESTATION_NOT_FOUND.1)?;
+			let mut existing_attestation = <Attestations<T>>::get(claim_hash.clone())
+				.ok_or(Self::error(Self::ERROR_ATTESTATION_NOT_FOUND).err().unwrap())?;
 			// if the sender of the revocation transaction is not the attester, check delegation tree
 			if !existing_attestation.1.eq(&sender) {
 				match existing_attestation.2 {

--- a/runtime/src/attestation/mod.rs
+++ b/runtime/src/attestation/mod.rs
@@ -75,7 +75,7 @@ decl_module! {
 						return Self::error(<delegation::Module<T>>::ERROR_DELEGATION_NOT_FOUND);
 					}
 					let delegation = <delegation::Delegations<T>>::get(d.clone())
-						.ok_or(Self::error(<delegation::Module<T>>::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
+						.ok_or_else(||Self::error(<delegation::Module<T>>::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 					if delegation.4 {
 						// delegation has been revoked
 						return Self::error(Self::ERROR_DELEGATION_REVOKED);
@@ -88,7 +88,7 @@ decl_module! {
 					} else {
 						// check if CTYPE of the delegation is matching the CTYPE of the attestation
 						let root = <delegation::Root<T>>::get(delegation.0.clone())
-							.ok_or(Self::error(<delegation::Module<T>>::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
+							.ok_or_else(||Self::error(<delegation::Module<T>>::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 						if !root.0.eq(&ctype_hash) {
 							return Self::error(Self::ERROR_CTYPE_OF_DELEGATION_NOT_MATCHING);
 						}
@@ -136,7 +136,7 @@ decl_module! {
 
 			// lookup attestation
 			let mut existing_attestation = <Attestations<T>>::get(claim_hash.clone())
-				.ok_or(Self::error(Self::ERROR_ATTESTATION_NOT_FOUND).err().unwrap())?;
+				.ok_or_else(||Self::error(Self::ERROR_ATTESTATION_NOT_FOUND).err().unwrap())?;
 			// if the sender of the revocation transaction is not the attester, check delegation tree
 			if !existing_attestation.1.eq(&sender) {
 				match existing_attestation.2 {

--- a/runtime/src/attestation/tests.rs
+++ b/runtime/src/attestation/tests.rs
@@ -89,7 +89,11 @@ fn check_add_attestation() {
         let account_hash = pair.public();
         assert_ok!(CType::add(Origin::signed(account_hash.clone()), hash.clone()));
         assert_ok!(Attestation::add(Origin::signed(account_hash.clone()), hash.clone(), hash.clone(), None));
-        let existing_attestation_for_claim = Attestation::attestations(hash.clone());
+        let existing_attestation_for_claim = {
+            let opt = Attestation::attestations(hash.clone());
+            assert!(opt.is_some());
+            opt.unwrap()
+        };
         assert_eq!(existing_attestation_for_claim.0, hash.clone());
         assert_eq!(existing_attestation_for_claim.1, account_hash.clone());
         assert_eq!(existing_attestation_for_claim.3, false);
@@ -105,7 +109,11 @@ fn check_revoke_attestation() {
         assert_ok!(CType::add(Origin::signed(account_hash.clone()), hash.clone()));
         assert_ok!(Attestation::add(Origin::signed(account_hash.clone()), hash.clone(), hash.clone(), None));
         assert_ok!(Attestation::revoke(Origin::signed(account_hash.clone()), hash.clone()));
-        let existing_attestation_for_claim = Attestation::attestations(hash.clone());
+        let existing_attestation_for_claim = {
+            let opt = Attestation::attestations(hash.clone());
+            assert!(opt.is_some());
+            opt.unwrap()
+        };
         assert_eq!(existing_attestation_for_claim.0, hash.clone());
         assert_eq!(existing_attestation_for_claim.1, account_hash.clone());
         assert_eq!(existing_attestation_for_claim.3, true);

--- a/runtime/src/ctype/mod.rs
+++ b/runtime/src/ctype/mod.rs
@@ -73,7 +73,7 @@ decl_module! {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Ctype {
-		// CTYPEs: ctype-hash -> account-id
+		// CTYPEs: ctype-hash -> account-id?
 		pub CTYPEs get(ctypes): map T::Hash => Option<T::AccountId>;
 	}
 }

--- a/runtime/src/ctype/mod.rs
+++ b/runtime/src/ctype/mod.rs
@@ -16,7 +16,6 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-
 //! CTYPE: Handles CTYPEs on chain,
 //! adding CTYPEs.
 
@@ -24,8 +23,9 @@
 #[cfg(test)]
 mod tests;
 
-use support::{dispatch::Result, StorageMap, decl_module, decl_storage, decl_event};
-use {system, system::ensure_signed, super::error};
+use super::error;
+use support::{decl_event, decl_module, decl_storage, dispatch::Result, StorageMap};
+use system::{self, ensure_signed};
 
 /// The CTYPE trait
 pub trait Trait: system::Trait + error::Trait {
@@ -74,20 +74,20 @@ decl_module! {
 decl_storage! {
 	trait Store for Module<T: Trait> as Ctype {
 		// CTYPEs: ctype-hash -> account-id
-		pub CTYPEs get(ctypes): map T::Hash => T::AccountId;
+		pub CTYPEs get(ctypes): map T::Hash => Option<T::AccountId>;
 	}
 }
 
 /// Implementation of further module constants and functions for CTYPEs
 impl<T: Trait> Module<T> {
-    
 	/// Error types for errors in CTYPE module
-    pub const ERROR_BASE: u16 = 1000;
-    pub const ERROR_CTYPE_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 1, "CTYPE not found");
-    pub const ERROR_CTYPE_ALREADY_EXISTS : error::ErrorType = (Self::ERROR_BASE + 2, "CTYPE already exists");
+	pub const ERROR_BASE: u16 = 1000;
+	pub const ERROR_CTYPE_NOT_FOUND: error::ErrorType = (Self::ERROR_BASE + 1, "CTYPE not found");
+	pub const ERROR_CTYPE_ALREADY_EXISTS: error::ErrorType =
+		(Self::ERROR_BASE + 2, "CTYPE already exists");
 
 	/// Create an error using the error module
-    pub fn error(error_type: error::ErrorType) -> Result {
-        return <error::Module<T>>::error(error_type);
-    }
+	pub fn error(error_type: error::ErrorType) -> Result {
+		return <error::Module<T>>::error(error_type);
+	}
 }

--- a/runtime/src/ctype/tests.rs
+++ b/runtime/src/ctype/tests.rs
@@ -76,7 +76,7 @@ fn it_works_for_default_value() {
             )
         );
         assert_eq!(<CTYPEs<Test>>::exists(ctype_hash), true);
-        assert_eq!(CType::ctypes(ctype_hash.clone()), account.clone());
+        assert_eq!(CType::ctypes(ctype_hash.clone()), Some(account.clone()));
         assert_err!(
             CType::add(
                 Origin::signed(account.clone()),

--- a/runtime/src/delegation/mod.rs
+++ b/runtime/src/delegation/mod.rs
@@ -375,9 +375,9 @@ impl<T: Trait> Module<T> {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Delegation {
-		// Root: root-id => (ctype-hash, account, revoked)
+		// Root: root-id => (ctype-hash, account, revoked)?
 		pub Root get(root): map T::DelegationNodeId => Option<(T::Hash,T::AccountId,bool)>;
-		// Delegations: delegation-id => (root-id, parent-id?, account, permissions, revoked)
+		// Delegations: delegation-id => (root-id, parent-id?, account, permissions, revoked)?
 		pub Delegations get(delegation): map T::DelegationNodeId => Option<(T::DelegationNodeId,Option<T::DelegationNodeId>,T::AccountId,Permissions,bool)>;
 		// Children: root-or-delegation-id => [delegation-id]
 		pub Children get(children): map T::DelegationNodeId => Vec<T::DelegationNodeId>;

--- a/runtime/src/delegation/mod.rs
+++ b/runtime/src/delegation/mod.rs
@@ -158,13 +158,15 @@ decl_module! {
 			
 			// check if root exists
 			if <Root<T>>::exists(root_id) {
-				let root = <Root<T>>::get(root_id.clone()).ok_or(Self::ERROR_ROOT_NOT_FOUND.1)?;
+				let root = <Root<T>>::get(root_id.clone())
+					.ok_or(Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 				// check if this delegation has a parent
 				match parent_id {
 					Some(p) => {
 						// check if the parent exists
 						if <Delegations<T>>::exists(p) {
-							let parent = <Delegations<T>>::get(p.clone()).ok_or(Self::ERROR_DELEGATION_NOT_FOUND.1)?;
+							let parent = <Delegations<T>>::get(p.clone())
+								.ok_or(Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 							// check if the parent's delegate is the sender of this transaction and has permission to delegate
 							if !parent.2.eq(&sender) {
 								return Self::error(Self::ERROR_NOT_OWNER_OF_PARENT);
@@ -214,7 +216,8 @@ decl_module! {
 			if !<Root<T>>::exists(root_id) {
 				return Self::error(Self::ERROR_ROOT_NOT_FOUND);
 			}
-			let mut r = <Root<T>>::get(root_id.clone()).ok_or(Self::ERROR_ROOT_NOT_FOUND.1)?;
+			let mut r = <Root<T>>::get(root_id.clone())
+				.ok_or(Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 			// check if root node has been created by the sender of this transaction
 			if !r.1.eq(&sender) {
 				return Self::error(Self::ERROR_NOT_PERMITTED_TO_REVOKE);
@@ -297,7 +300,8 @@ impl<T: Trait> Module<T> {
 		if !<Delegations<T>>::exists(delegation) {
 			Self::error(Self::ERROR_DELEGATION_NOT_FOUND)?
 		}
-		let d = <Delegations<T>>::get(delegation).ok_or(Self::ERROR_DELEGATION_NOT_FOUND.1)?;
+		let d = <Delegations<T>>::get(delegation)
+			.ok_or(Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 		// check if the account is the owner of the delegation
 		if d.2.eq(account) {
 			Ok(true)
@@ -306,7 +310,8 @@ impl<T: Trait> Module<T> {
 			match d.1 {
 				None => {
 					// return whether the account is owner of the root
-					let r = <Root<T>>::get(d.0.clone()).ok_or(Self::ERROR_ROOT_NOT_FOUND.1)?;
+					let r = <Root<T>>::get(d.0.clone())
+						.ok_or(Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 					Ok(r.1.eq(account))
 				},
 				Some(p) => {
@@ -320,7 +325,8 @@ impl<T: Trait> Module<T> {
 	/// Revoke a delegation an all of its children
 	fn revoke(delegation: &T::DelegationNodeId, sender: &T::AccountId) -> Result {
 		// retrieve delegation node from storage
-		let mut d = <Delegations<T>>::get(delegation.clone()).ok_or(Self::ERROR_DELEGATION_NOT_FOUND.1)?;
+		let mut d = <Delegations<T>>::get(delegation.clone())
+			.ok_or(Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 		// check if already revoked
 		if !d.4 {
 			// set revoked flag and store delegation node

--- a/runtime/src/delegation/mod.rs
+++ b/runtime/src/delegation/mod.rs
@@ -160,14 +160,14 @@ decl_module! {
 			// check if root exists
 			if <Root<T>>::exists(root_id) {
 				let root = <Root<T>>::get(root_id.clone())
-					.ok_or(Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
+					.ok_or_else(||Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 				// check if this delegation has a parent
 				match parent_id {
 					Some(p) => {
 						// check if the parent exists
 						if <Delegations<T>>::exists(p) {
 							let parent = <Delegations<T>>::get(p.clone())
-								.ok_or(Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
+								.ok_or_else(||Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 							// check if the parent's delegate is the sender of this transaction and has permission to delegate
 							if !parent.2.eq(&sender) {
 								return Self::error(Self::ERROR_NOT_OWNER_OF_PARENT);
@@ -218,7 +218,7 @@ decl_module! {
 				return Self::error(Self::ERROR_ROOT_NOT_FOUND);
 			}
 			let mut r = <Root<T>>::get(root_id.clone())
-				.ok_or(Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
+				.ok_or_else(||Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 			// check if root node has been created by the sender of this transaction
 			if !r.1.eq(&sender) {
 				return Self::error(Self::ERROR_NOT_PERMITTED_TO_REVOKE);
@@ -307,7 +307,7 @@ impl<T: Trait> Module<T> {
 			Self::error(Self::ERROR_DELEGATION_NOT_FOUND)?;
 		}
 		let d = <Delegations<T>>::get(delegation)
-			.ok_or(Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
+			.ok_or_else(|| Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 		// check if the account is the owner of the delegation
 		if d.2.eq(account) {
 			Ok(true)
@@ -317,7 +317,7 @@ impl<T: Trait> Module<T> {
 				None => {
 					// return whether the account is owner of the root
 					let r = <Root<T>>::get(d.0.clone())
-						.ok_or(Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
+						.ok_or_else(|| Self::error(Self::ERROR_ROOT_NOT_FOUND).err().unwrap())?;
 					Ok(r.1.eq(account))
 				}
 				Some(p) => {
@@ -332,7 +332,7 @@ impl<T: Trait> Module<T> {
 	fn revoke(delegation: &T::DelegationNodeId, sender: &T::AccountId) -> Result {
 		// retrieve delegation node from storage
 		let mut d = <Delegations<T>>::get(delegation.clone())
-			.ok_or(Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
+			.ok_or_else(|| Self::error(Self::ERROR_DELEGATION_NOT_FOUND).err().unwrap())?;
 		// check if already revoked
 		if !d.4 {
 			// set revoked flag and store delegation node

--- a/runtime/src/delegation/mod.rs
+++ b/runtime/src/delegation/mod.rs
@@ -38,63 +38,63 @@ use {system::{self, ensure_signed}, super::ctype, super::error};
 use runtime_primitives::verify_encoded_lazy;
 
 bitflags! {
-    /// Bitflags for permissions
-    #[derive(Encode, Decode)]
-    pub struct Permissions: u32 {
-        /// Bit flag for attestation permission
-        const ATTEST = 0b00000001;
-        /// Bit flag for delegation permission
-        const DELEGATE = 0b00000010;
-    }
+	/// Bitflags for permissions
+	#[derive(Encode, Decode)]
+	pub struct Permissions: u32 {
+		/// Bit flag for attestation permission
+		const ATTEST = 0b00000001;
+		/// Bit flag for delegation permission
+		const DELEGATE = 0b00000010;
+	}
 }
 
 /// Implementation for permissions
 impl Permissions {
-    /// Encode permission bitflags into u8 array
-    fn as_u8(&self) -> [u8;4] {
-        let x: u32 = (*self).bits;
-        let b1 : u8 = ((x >> 24) & 0xff) as u8;
-        let b2 : u8 = ((x >> 16) & 0xff) as u8;
-        let b3 : u8 = ((x >> 8) & 0xff) as u8;
-        let b4 : u8 = (x & 0xff) as u8;
-        return [b4, b3, b2, b1];
-    }
+	/// Encode permission bitflags into u8 array
+	fn as_u8(&self) -> [u8;4] {
+		let x: u32 = (*self).bits;
+		let b1 : u8 = ((x >> 24) & 0xff) as u8;
+		let b2 : u8 = ((x >> 16) & 0xff) as u8;
+		let b3 : u8 = ((x >> 8) & 0xff) as u8;
+		let b4 : u8 = (x & 0xff) as u8;
+		return [b4, b3, b2, b1];
+	}
 }
 
 /// Implement Default trait for permissions
 impl Default for Permissions {
-    /// Default permissions to the attest permission
-    fn default() -> Self {
-        return Permissions::ATTEST;
-    }
+	/// Default permissions to the attest permission
+	fn default() -> Self {
+		return Permissions::ATTEST;
+	}
 }
 
 /// The delegation trait
 pub trait Trait: ctype::Trait + system::Trait + error::Trait {
 	/// Delegation specific event type
-    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 
-    /// Signer of a delegation
-    type Signer: From<Self::AccountId> + Member + Codec;
-    /// Signature of a delegation
+	/// Signer of a delegation
+	type Signer: From<Self::AccountId> + Member + Codec;
+	/// Signature of a delegation
 	type Signature: Verify<Signer = Self::Signer> + Member + Codec + Default;
-    /// Delegation node id type
-    type DelegationNodeId: Parameter + Member + Codec + MaybeDisplay + SimpleBitOps 
-            + Default + Copy + CheckEqual + rstd::hash::Hash + AsRef<[u8]> + AsMut<[u8]>;
+	/// Delegation node id type
+	type DelegationNodeId: Parameter + Member + Codec + MaybeDisplay + SimpleBitOps 
+			+ Default + Copy + CheckEqual + rstd::hash::Hash + AsRef<[u8]> + AsMut<[u8]>;
 }
 
 
 decl_event!(
 	/// Events for delegations
 	pub enum Event<T> where <T as system::Trait>::Hash, <T as system::Trait>::AccountId, 
-            <T as Trait>::DelegationNodeId {
+			<T as Trait>::DelegationNodeId {
 		/// A new root has been created
 		RootCreated(AccountId, DelegationNodeId, Hash),
 		/// A root has been revoked
 		RootRevoked(AccountId, DelegationNodeId),
 		/// A new delegation has been created
 		DelegationCreated(AccountId, DelegationNodeId, DelegationNodeId, Option<DelegationNodeId>, 
-                AccountId, Permissions),
+				AccountId, Permissions),
 		/// A delegation has been revoked
 		DelegationRevoked(AccountId, DelegationNodeId),
 	}
@@ -104,9 +104,9 @@ decl_event!(
 decl_module! {
 	/// The delegation runtime module
 	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-            
+			
 		/// Deposit events
-        fn deposit_event<T>() = default;
+		fn deposit_event<T>() = default;
 
 		/// Creates a delegation hierarchy root on chain, where
 		/// origin - the origin of the transaction
@@ -115,255 +115,256 @@ decl_module! {
 		pub fn create_root(origin, root_id: T::DelegationNodeId, ctype_hash: T::Hash) -> Result {
 			// origin of the transaction needs to be a signed sender account
 			let sender = ensure_signed(origin)?;
-            // check if a root with the given id already exsists
-            if <Root<T>>::exists(root_id) {
-                return Self::error(Self::ERROR_ROOT_ALREADY_EXISTS);
-            }
-            // check if CTYPE exists
-            if !<ctype::CTYPEs<T>>::exists(ctype_hash) {
-                return Self::error(<ctype::Module<T>>::ERROR_CTYPE_NOT_FOUND);
-            }
+			// check if a root with the given id already exsists
+			if <Root<T>>::exists(root_id) {
+				return Self::error(Self::ERROR_ROOT_ALREADY_EXISTS);
+			}
+			// check if CTYPE exists
+			if !<ctype::CTYPEs<T>>::exists(ctype_hash) {
+				return Self::error(<ctype::Module<T>>::ERROR_CTYPE_NOT_FOUND);
+			}
 
-            // add root node to storage
+			// add root node to storage
 			::runtime_io::print("insert Delegation Root");
 			<Root<T>>::insert(root_id.clone(), (ctype_hash.clone(), sender.clone(), false));
-            // deposit event that the root node has been created
-            Self::deposit_event(RawEvent::RootCreated(sender.clone(), root_id.clone(), ctype_hash.clone()));
-            Ok(())
-        }
+			// deposit event that the root node has been created
+			Self::deposit_event(RawEvent::RootCreated(sender.clone(), root_id.clone(), ctype_hash.clone()));
+			Ok(())
+		}
 		
 		/// Adds a delegation node on chain, where
 		/// origin - the origin of the transaction
 		/// delegation_id - unique identifier of the delegation node to be added
 		/// root_id - id of the hierarchy root node 
-        /// parent_id - optional identifier of a parent node this delegeation node is created under
+		/// parent_id - optional identifier of a parent node this delegeation node is created under
 		/// delegate - the delefate account
-        /// permission - the permissions delegated
-        /// delegate_signature - the signature of the delegate to ensure it's done under his permission
-        pub fn add_delegation(origin, delegation_id: T::DelegationNodeId, 
-                root_id: T::DelegationNodeId, parent_id: Option<T::DelegationNodeId>, 
-                delegate: T::AccountId, permissions: Permissions, delegate_signature: T::Signature) -> Result {
+		/// permission - the permissions delegated
+		/// delegate_signature - the signature of the delegate to ensure it's done under his permission
+		pub fn add_delegation(origin, delegation_id: T::DelegationNodeId, 
+				root_id: T::DelegationNodeId, parent_id: Option<T::DelegationNodeId>, 
+				delegate: T::AccountId, permissions: Permissions, delegate_signature: T::Signature) -> Result {
 			// origin of the transaction needs to be a signed sender account
 			let sender = ensure_signed(origin)?;
-            // check if a delegation node with the given identifier already exists
-            if <Delegations<T>>::exists(delegation_id) {
-                return Self::error(Self::ERROR_DELEGATION_ALREADY_EXISTS);
-            }
-            
-            // calculate the hash root and check if the signature matches
-            let hash_root = Self::calculate_hash(delegation_id, root_id, parent_id, permissions);
-            if !verify_encoded_lazy(&delegate_signature, &&hash_root, &delegate.clone().into()) {
-                return Self::error(Self::ERROR_BAD_DELEGATION_SIGNATURE);
-            }
-            
-            // check if root exists
-            if <Root<T>>::exists(root_id) {
-                let root = <Root<T>>::get(root_id.clone());
-                // check if this delegation has a parent
-                match parent_id {
-                    Some(p) => {
-                        // check if the parent exists
-                        if <Delegations<T>>::exists(p) {
-                            let parent = <Delegations<T>>::get(p.clone());
-                            // check if the parent's delegate is the sender of this transaction and has permission to delegate
-                            if !parent.2.eq(&sender) {
-                                return Self::error(Self::ERROR_NOT_OWNER_OF_PARENT);
-                            } else if (parent.3 & Permissions::DELEGATE) != Permissions::DELEGATE {
-                                return Self::error(Self::ERROR_NOT_AUTHORIZED_TO_DELEGATE);
-                            } else {
-                                // insert delegation
-                    			::runtime_io::print("insert Delegation with parent");
-                                <Delegations<T>>::insert(delegation_id.clone(), (root_id.clone(), 
-                                        Some(p.clone()), delegate.clone(), permissions, false));
-                                // add child to tree structure
-                                Self::add_child(delegation_id.clone(), p.clone());
-                            }
-                        } else {
-                            return Self::error(Self::ERROR_PARENT_NOT_FOUND);
-                        }
-                    },
-                    None => {
-                        // check if the sender of this transaction is the creator of the root node (as no parent is given)
-                        if !root.1.eq(&sender) {
-                            return Self::error(Self::ERROR_NOT_OWNER_OF_ROOT);       
-                        }
-                        // inser delegation
-                        ::runtime_io::print("insert Delegation without parent");
-                        <Delegations<T>>::insert(delegation_id.clone(), (root_id.clone(), 
-                                None, delegate.clone(), permissions, false));
-                        // add child to tree structure
-                        Self::add_child(delegation_id.clone(), root_id.clone());
-                    }
-                }
-            } else {
-                return Self::error(Self::ERROR_ROOT_NOT_FOUND);
-            }
-            // deposit event that the delegation node has been added
-            Self::deposit_event(RawEvent::DelegationCreated(sender.clone(), delegation_id.clone(), 
-                    root_id.clone(), parent_id.clone(), delegate.clone(), permissions.clone()));
-            Ok(())
-        }
+			// check if a delegation node with the given identifier already exists
+			if <Delegations<T>>::exists(delegation_id) {
+				return Self::error(Self::ERROR_DELEGATION_ALREADY_EXISTS);
+			}
+			
+			// calculate the hash root and check if the signature matches
+			let hash_root = Self::calculate_hash(delegation_id, root_id, parent_id, permissions);
+			if !verify_encoded_lazy(&delegate_signature, &&hash_root, &delegate.clone().into()) {
+				return Self::error(Self::ERROR_BAD_DELEGATION_SIGNATURE);
+			}
+			
+			// check if root exists
+			if <Root<T>>::exists(root_id) {
+				let root = <Root<T>>::get(root_id.clone()).ok_or(Self::ERROR_ROOT_NOT_FOUND.1)?;
+				// check if this delegation has a parent
+				match parent_id {
+					Some(p) => {
+						// check if the parent exists
+						if <Delegations<T>>::exists(p) {
+							let parent = <Delegations<T>>::get(p.clone()).ok_or(Self::ERROR_DELEGATION_NOT_FOUND.1)?;
+							// check if the parent's delegate is the sender of this transaction and has permission to delegate
+							if !parent.2.eq(&sender) {
+								return Self::error(Self::ERROR_NOT_OWNER_OF_PARENT);
+							} else if (parent.3 & Permissions::DELEGATE) != Permissions::DELEGATE {
+								return Self::error(Self::ERROR_NOT_AUTHORIZED_TO_DELEGATE);
+							} else {
+								// insert delegation
+								::runtime_io::print("insert Delegation with parent");
+								<Delegations<T>>::insert(delegation_id.clone(), (root_id.clone(), 
+										Some(p.clone()), delegate.clone(), permissions, false));
+								// add child to tree structure
+								Self::add_child(delegation_id.clone(), p.clone());
+							}
+						} else {
+							return Self::error(Self::ERROR_PARENT_NOT_FOUND);
+						}
+					},
+					None => {
+						// check if the sender of this transaction is the creator of the root node (as no parent is given)
+						if !root.1.eq(&sender) {
+							return Self::error(Self::ERROR_NOT_OWNER_OF_ROOT);	   
+						}
+						// inser delegation
+						::runtime_io::print("insert Delegation without parent");
+						<Delegations<T>>::insert(delegation_id.clone(), (root_id.clone(), 
+								None, delegate.clone(), permissions, false));
+						// add child to tree structure
+						Self::add_child(delegation_id.clone(), root_id.clone());
+					}
+				}
+			} else {
+				return Self::error(Self::ERROR_ROOT_NOT_FOUND);
+			}
+			// deposit event that the delegation node has been added
+			Self::deposit_event(RawEvent::DelegationCreated(sender.clone(), delegation_id.clone(), 
+					root_id.clone(), parent_id.clone(), delegate.clone(), permissions.clone()));
+			Ok(())
+		}
 
 		/// Revoke the root and therefore a complete hierarchy, where
 		/// origin - the origin of the transaction
 		/// root_id - id of the hierarchy root node 
-        pub fn revoke_root(origin, root_id: T::DelegationNodeId) -> Result {
+		pub fn revoke_root(origin, root_id: T::DelegationNodeId) -> Result {
 			// origin of the transaction needs to be a signed sender account
 			let sender = ensure_signed(origin)?;
-            // check if root node exists
-            if !<Root<T>>::exists(root_id) {
-                return Self::error(Self::ERROR_ROOT_NOT_FOUND);
-            }
-            let mut r = <Root<T>>::get(root_id.clone());
-            // check if root node has been created by the sender of this transaction
-            if !r.1.eq(&sender) {
-                return Self::error(Self::ERROR_NOT_PERMITTED_TO_REVOKE);
-            }
-            if !r.2 {
-                // store revoked root node
-                r.2 = true;
-                <Root<T>>::insert(root_id.clone(), r);
-                // recursively revoke all children
-                Self::revoke_children(&root_id, &sender);
-            }
-            // deposit event that the root node has been revoked
-            Self::deposit_event(RawEvent::RootRevoked(sender.clone(), root_id.clone()));
-            Ok(())
-        }
+			// check if root node exists
+			if !<Root<T>>::exists(root_id) {
+				return Self::error(Self::ERROR_ROOT_NOT_FOUND);
+			}
+			let mut r = <Root<T>>::get(root_id.clone()).ok_or(Self::ERROR_ROOT_NOT_FOUND.1)?;
+			// check if root node has been created by the sender of this transaction
+			if !r.1.eq(&sender) {
+				return Self::error(Self::ERROR_NOT_PERMITTED_TO_REVOKE);
+			}
+			if !r.2 {
+				// store revoked root node
+				r.2 = true;
+				<Root<T>>::insert(root_id.clone(), r);
+				// recursively revoke all children
+				Self::revoke_children(&root_id, &sender)?;
+			}
+			// deposit event that the root node has been revoked
+			Self::deposit_event(RawEvent::RootRevoked(sender.clone(), root_id.clone()));
+			Ok(())
+		}
 
 		/// Revoke a delegation node and all its children, where
 		/// origin - the origin of the transaction
 		/// delegation_id - id of the delegation node 
-        pub fn revoke_delegation(origin, delegation_id: T::DelegationNodeId) -> Result {
+		pub fn revoke_delegation(origin, delegation_id: T::DelegationNodeId) -> Result {
 			// origin of the transaction needs to be a signed sender account
 			let sender = ensure_signed(origin)?;
-            // check if delegation node exists
-            if !<Delegations<T>>::exists(delegation_id) {
-                return Self::error(Self::ERROR_DELEGATION_NOT_FOUND)
-            }
-            // check if the sender of this transaction is permitted by being the 
-            // owner of the delegation or of one of its parents
-            if !Self::is_delegating(&sender, &delegation_id)? {
-                return Self::error(Self::ERROR_NOT_PERMITTED_TO_REVOKE)
-            }
-            // revoke the delegation and recursively all of its children
-            Self::revoke(&delegation_id, &sender);
-            Ok(())
-        }
-    }
+			// check if delegation node exists
+			if !<Delegations<T>>::exists(delegation_id) {
+				return Self::error(Self::ERROR_DELEGATION_NOT_FOUND)
+			}
+			// check if the sender of this transaction is permitted by being the 
+			// owner of the delegation or of one of its parents
+			if !Self::is_delegating(&sender, &delegation_id)? {
+				return Self::error(Self::ERROR_NOT_PERMITTED_TO_REVOKE)
+			}
+			// revoke the delegation and recursively all of its children
+			Self::revoke(&delegation_id, &sender)?;
+			Ok(())
+		}
+	}
 }
 
 /// Implementation of further module constants and functions for delegations
 impl<T: Trait> Module<T> {
-    
+	
 	/// Error types for errors in delegation module
-    pub const ERROR_BASE: u16 = 3000;
-    pub const ERROR_ROOT_ALREADY_EXISTS : error::ErrorType = (Self::ERROR_BASE + 1, "root already exist");
-    pub const ERROR_NOT_PERMITTED_TO_REVOKE : error::ErrorType = (Self::ERROR_BASE + 2, "not permitted to revoke");
-    pub const ERROR_DELEGATION_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 3, "delegation not found");
-    pub const ERROR_DELEGATION_ALREADY_EXISTS : error::ErrorType = (Self::ERROR_BASE + 4, "delegation already exist");
-    pub const ERROR_BAD_DELEGATION_SIGNATURE : error::ErrorType = (Self::ERROR_BASE + 5, "bad delegate signature");
-    pub const ERROR_NOT_OWNER_OF_PARENT : error::ErrorType = (Self::ERROR_BASE + 6, "not owner of parent");
-    pub const ERROR_NOT_AUTHORIZED_TO_DELEGATE : error::ErrorType = (Self::ERROR_BASE + 7, "not authorized to delegate");
-    pub const ERROR_PARENT_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 8, "parent not found");
-    pub const ERROR_NOT_OWNER_OF_ROOT : error::ErrorType = (Self::ERROR_BASE + 9, "not owner of root");
-    pub const ERROR_ROOT_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 10, "root not found");
+	pub const ERROR_BASE: u16 = 3000;
+	pub const ERROR_ROOT_ALREADY_EXISTS : error::ErrorType = (Self::ERROR_BASE + 1, "root already exist");
+	pub const ERROR_NOT_PERMITTED_TO_REVOKE : error::ErrorType = (Self::ERROR_BASE + 2, "not permitted to revoke");
+	pub const ERROR_DELEGATION_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 3, "delegation not found");
+	pub const ERROR_DELEGATION_ALREADY_EXISTS : error::ErrorType = (Self::ERROR_BASE + 4, "delegation already exist");
+	pub const ERROR_BAD_DELEGATION_SIGNATURE : error::ErrorType = (Self::ERROR_BASE + 5, "bad delegate signature");
+	pub const ERROR_NOT_OWNER_OF_PARENT : error::ErrorType = (Self::ERROR_BASE + 6, "not owner of parent");
+	pub const ERROR_NOT_AUTHORIZED_TO_DELEGATE : error::ErrorType = (Self::ERROR_BASE + 7, "not authorized to delegate");
+	pub const ERROR_PARENT_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 8, "parent not found");
+	pub const ERROR_NOT_OWNER_OF_ROOT : error::ErrorType = (Self::ERROR_BASE + 9, "not owner of root");
+	pub const ERROR_ROOT_NOT_FOUND : error::ErrorType = (Self::ERROR_BASE + 10, "root not found");
 
 	/// Create an error using the error module
-    pub fn error(error_type: error::ErrorType) -> Result {
-        return <error::Module<T>>::error(error_type);
-    }
+	pub fn error(error_type: error::ErrorType) -> Result {
+		return <error::Module<T>>::error(error_type);
+	}
 
-    /// Calculates the hash of all values of a delegtion transaction
-    pub fn calculate_hash(delegation_id: T::DelegationNodeId, 
-                root_id: T::DelegationNodeId, parent_id: Option<T::DelegationNodeId>, 
-                permissions: Permissions) -> T::Hash {
-        // add all values to an u8 vector
-        let mut hashed_values : Vec<u8> = delegation_id.as_ref().to_vec();
-        hashed_values.extend_from_slice(root_id.as_ref());
-        match parent_id {
-            Some(p) => hashed_values.extend_from_slice(p.as_ref()),
-            None => {}
-        }
-        hashed_values.extend_from_slice(permissions.as_u8().as_ref());
-        // hash vector
-        let hash_root = T::Hashing::hash(&hashed_values);
-        return hash_root;
-    }
+	/// Calculates the hash of all values of a delegtion transaction
+	pub fn calculate_hash(delegation_id: T::DelegationNodeId, 
+				root_id: T::DelegationNodeId, parent_id: Option<T::DelegationNodeId>, 
+				permissions: Permissions) -> T::Hash {
+		// add all values to an u8 vector
+		let mut hashed_values : Vec<u8> = delegation_id.as_ref().to_vec();
+		hashed_values.extend_from_slice(root_id.as_ref());
+		match parent_id {
+			Some(p) => hashed_values.extend_from_slice(p.as_ref()),
+			None => {}
+		}
+		hashed_values.extend_from_slice(permissions.as_u8().as_ref());
+		// hash vector
+		let hash_root = T::Hashing::hash(&hashed_values);
+		return hash_root;
+	}
 
-    /// Check if an account is the owner of the delegation or any delegation up the hierarchy (including the root)
-    pub fn is_delegating(account: &T::AccountId, delegation: &T::DelegationNodeId) -> result::Result<bool, &'static str> {
-        // check if delegation exists
-        if !<Delegations<T>>::exists(delegation) {
-            Self::error(Self::ERROR_DELEGATION_NOT_FOUND)?
-        }
-        let d = <Delegations<T>>::get(delegation);
-        // check if the account is the owner of the delegation
-        if d.2.eq(account) {
-            Ok(true)
-        } else {
-            // check if there's a parent
-            match d.1 {
-                None => {
-                    // return whether the account is owner of the root
-                    let r = <Root<T>>::get(d.0.clone());
-                    Ok(r.1.eq(account))
-                },
-                Some(p) => {
-                    // recurse upwards in hierarchy
-                    return Self::is_delegating(account, &p)
-                }
-            }
-        }
-    }
+	/// Check if an account is the owner of the delegation or any delegation up the hierarchy (including the root)
+	pub fn is_delegating(account: &T::AccountId, delegation: &T::DelegationNodeId) -> result::Result<bool, &'static str> {
+		// check if delegation exists
+		if !<Delegations<T>>::exists(delegation) {
+			Self::error(Self::ERROR_DELEGATION_NOT_FOUND)?
+		}
+		let d = <Delegations<T>>::get(delegation).ok_or(Self::ERROR_DELEGATION_NOT_FOUND.1)?;
+		// check if the account is the owner of the delegation
+		if d.2.eq(account) {
+			Ok(true)
+		} else {
+			// check if there's a parent
+			match d.1 {
+				None => {
+					// return whether the account is owner of the root
+					let r = <Root<T>>::get(d.0.clone()).ok_or(Self::ERROR_ROOT_NOT_FOUND.1)?;
+					Ok(r.1.eq(account))
+				},
+				Some(p) => {
+					// recurse upwards in hierarchy
+					return Self::is_delegating(account, &p)
+				}
+			}
+		}
+	}
 
-    /// Revoke a delegation an all of its children
-    fn revoke(delegation: &T::DelegationNodeId, sender: &T::AccountId) {
-        // retrieve delegation node from storage
-        let mut d = <Delegations<T>>::get(delegation.clone());
-        // check if already revoked
-        if !d.4 {
-            // set revoked flag and store delegation node
-            d.4 = true;
-            <Delegations<T>>::insert(delegation.clone(), d);
-            // deposit event that the delegation has been revoked
-            Self::deposit_event(RawEvent::DelegationRevoked(sender.clone(), delegation.clone()));
-            // revoke all children recursively
-            Self::revoke_children(delegation, sender);
-        }
-    }
+	/// Revoke a delegation an all of its children
+	fn revoke(delegation: &T::DelegationNodeId, sender: &T::AccountId) -> Result {
+		// retrieve delegation node from storage
+		let mut d = <Delegations<T>>::get(delegation.clone()).ok_or(Self::ERROR_DELEGATION_NOT_FOUND.1)?;
+		// check if already revoked
+		if !d.4 {
+			// set revoked flag and store delegation node
+			d.4 = true;
+			<Delegations<T>>::insert(delegation.clone(), d);
+			// deposit event that the delegation has been revoked
+			Self::deposit_event(RawEvent::DelegationRevoked(sender.clone(), delegation.clone()));
+			// revoke all children recursively
+			Self::revoke_children(delegation, sender)?;
+		}
+		Ok(())
+	}
 
-    /// Revoke all children of a delegation
-    fn revoke_children(delegation: &T::DelegationNodeId, sender: &T::AccountId) {
-        // check if there's a child vector in the storage
-        if <Children<T>>::exists(delegation) {
-            // iterate child vector and revoke all nodes
-            let children = <Children<T>>::get(delegation);
-            for child in children {
-                Self::revoke(&child, sender);
-            }
-        }
-    }
+	/// Revoke all children of a delegation
+	fn revoke_children(delegation: &T::DelegationNodeId, sender: &T::AccountId) -> Result {
+		// check if there's a child vector in the storage
+		if <Children<T>>::exists(delegation) {
+			// iterate child vector and revoke all nodes
+			let children = <Children<T>>::get(delegation);
+			for child in children {
+				Self::revoke(&child, sender)?;
+			}
+		}
+		Ok(())
+	}
 
-    /// Add a child node into the delegation hierarchy
-    fn add_child(child: T::DelegationNodeId, parent: T::DelegationNodeId) {
-        // get the children vector
-        let mut children = <Children<T>>::get(parent.clone());
-        // add child element
-        children.push(child);
-        // store vector with new child
-        <Children<T>>::insert(parent, children);
-    }
+	/// Add a child node into the delegation hierarchy
+	fn add_child(child: T::DelegationNodeId, parent: T::DelegationNodeId) {
+		// get the children vector
+		let mut children = <Children<T>>::get(parent.clone());
+		// add child element
+		children.push(child);
+		// store vector with new child
+		<Children<T>>::insert(parent, children);
+	}
 }
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Delegation {
-        // Root: root-id => (ctype-hash, account, revoked)
-		pub Root get(root): map T::DelegationNodeId => (T::Hash,T::AccountId,bool); 
-        // Delegations: delegation-id => (root-id, parent-id?, account, permissions, revoked)
-		pub Delegations get(delegation): map T::DelegationNodeId => (T::DelegationNodeId,Option<T::DelegationNodeId>,T::AccountId,Permissions,bool); 
+		// Root: root-id => (ctype-hash, account, revoked)
+		pub Root get(root): map T::DelegationNodeId => Option<(T::Hash,T::AccountId,bool)>; 
+		// Delegations: delegation-id => (root-id, parent-id?, account, permissions, revoked)
+		pub Delegations get(delegation): map T::DelegationNodeId => Option<(T::DelegationNodeId,Option<T::DelegationNodeId>,T::AccountId,Permissions,bool)>; 
 		// Children: root-or-delegation-id => [delegation-id]
-        pub Children get(children): map T::DelegationNodeId => Vec<T::DelegationNodeId>; 
+		pub Children get(children): map T::DelegationNodeId => Vec<T::DelegationNodeId>; 
 	}
 }
-

--- a/runtime/src/delegation/tests.rs
+++ b/runtime/src/delegation/tests.rs
@@ -92,7 +92,6 @@ fn check_add_and_revoke_delegations() {
         let id_level_2_1 = H256::from_low_u64_be(21);
         let id_level_2_2 = H256::from_low_u64_be(22);
         let id_level_2_2_1 = H256::from_low_u64_be(221);
-
         assert_ok!(CType::add(Origin::signed(account_hash_alice.clone()), ctype_hash.clone()));
 
         assert_ok!(Delegation::create_root(Origin::signed(account_hash_alice.clone()), id_level_0.clone(), ctype_hash.clone()));
@@ -157,19 +156,31 @@ fn check_add_and_revoke_delegations() {
                 Delegation::calculate_hash(id_level_2_2_1.clone(), id_level_0.clone(), Some(id_level_2_2.clone()), Permissions::ATTEST))))));
 
         
-        let root = Delegation::root(id_level_0.clone());
+        let root = {
+            let opt = Delegation::root(id_level_0.clone());
+            assert!(opt.is_some());
+            opt.unwrap()
+        };
         assert_eq!(root.0, ctype_hash.clone());
         assert_eq!(root.1, account_hash_alice.clone());
         assert_eq!(root.2, false);
 
-        let delegation_1 = Delegation::delegation(id_level_1.clone());
+        let delegation_1 = {
+            let opt = Delegation::delegation(id_level_1.clone());
+            assert!(opt.is_some());
+            opt.unwrap()
+        };
         assert_eq!(delegation_1.0, id_level_0.clone());
         assert_eq!(delegation_1.1, None);
         assert_eq!(delegation_1.2, account_hash_bob.clone());
         assert_eq!(delegation_1.3, Permissions::DELEGATE);
         assert_eq!(delegation_1.4, false);
 
-        let delegation_2 = Delegation::delegation(id_level_2_2.clone());
+        let delegation_2 = {
+            let opt = Delegation::delegation(id_level_2_2.clone());
+            assert!(opt.is_some());
+            opt.unwrap()
+        };
         assert_eq!(delegation_2.0, id_level_0.clone());
         assert_eq!(delegation_2.1, Some(id_level_1.clone()));
         assert_eq!(delegation_2.2, account_hash_charlie.clone());
@@ -195,17 +206,16 @@ fn check_add_and_revoke_delegations() {
             Delegation::ERROR_NOT_PERMITTED_TO_REVOKE.1);
         assert_ok!(Delegation::revoke_delegation(Origin::signed(account_hash_charlie.clone()), id_level_2_2.clone()));
         
-        assert_eq!(Delegation::delegation(id_level_2_2.clone()).4, true);
-        assert_eq!(Delegation::delegation(id_level_2_2_1.clone()).4, true);
-
+        assert_eq!(Delegation::delegation(id_level_2_2.clone()).unwrap().4, true);
+        assert_eq!(Delegation::delegation(id_level_2_2_1.clone()).unwrap().4, true);
         assert_err!(Delegation::revoke_root(Origin::signed(account_hash_bob.clone()), H256::from_low_u64_be(999)),
             Delegation::ERROR_ROOT_NOT_FOUND.1);
         assert_err!(Delegation::revoke_root(Origin::signed(account_hash_bob.clone()), id_level_0.clone()),
             Delegation::ERROR_NOT_PERMITTED_TO_REVOKE.1);
         assert_ok!(Delegation::revoke_root(Origin::signed(account_hash_alice.clone()), id_level_0.clone()));
         
-        assert_eq!(Delegation::root(id_level_0.clone()).2, true);
-        assert_eq!(Delegation::delegation(id_level_1.clone()).4, true);
-        assert_eq!(Delegation::delegation(id_level_2_1.clone()).4, true);
+        assert_eq!(Delegation::root(id_level_0.clone()).unwrap().2, true);
+        assert_eq!(Delegation::delegation(id_level_1.clone()).unwrap().4, true);
+        assert_eq!(Delegation::delegation(id_level_2_1.clone()).unwrap().4, true);
     });
 }

--- a/runtime/src/did/mod.rs
+++ b/runtime/src/did/mod.rs
@@ -85,7 +85,7 @@ decl_module! {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as DID {
-		// DID: account-id -> (public-signing-key, public-encryption-key, did-reference?)
+		// DID: account-id -> (public-signing-key, public-encryption-key, did-reference?)?
 		DIDs get(dids): map T::AccountId => Option<(T::PublicSigningKey, T::PublicBoxKey, Option<Vec<u8>>)>;
 	}
 }

--- a/runtime/src/did/mod.rs
+++ b/runtime/src/did/mod.rs
@@ -24,10 +24,9 @@
 mod tests;
 
 use rstd::prelude::*;
-use runtime_primitives::codec::Codec;
-use runtime_primitives::traits::Member;
+use runtime_primitives::{codec::Codec, traits::Member};
 use support::{decl_event, decl_module, decl_storage, dispatch::Result, Parameter, StorageMap};
-use {system, system::ensure_signed};
+use system::{self, ensure_signed};
 
 /// The DID trait
 pub trait Trait: system::Trait {

--- a/runtime/src/did/mod.rs
+++ b/runtime/src/did/mod.rs
@@ -16,7 +16,6 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-
 //! DID: Handles decentralized identifiers on chain,
 //! adding and removing DIDs.
 
@@ -25,9 +24,9 @@
 mod tests;
 
 use rstd::prelude::*;
-use runtime_primitives::traits::{Member};
-use support::{dispatch::Result, StorageMap, Parameter, decl_module, decl_storage, decl_event};
 use runtime_primitives::codec::Codec;
+use runtime_primitives::traits::Member;
+use support::{decl_event, decl_module, decl_storage, dispatch::Result, Parameter, StorageMap};
 use {system, system::ensure_signed};
 
 /// The DID trait
@@ -35,9 +34,9 @@ pub trait Trait: system::Trait {
 	/// DID specific event type
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 	/// Public signing key type for DIDs
-    type PublicSigningKey : Parameter + Member + Codec + Default;
+	type PublicSigningKey: Parameter + Member + Codec + Default;
 	/// Public boxing key type for DIDs
-    type PublicBoxKey : Parameter + Member + Codec + Default;
+	type PublicBoxKey: Parameter + Member + Codec + Default;
 }
 
 decl_event!(
@@ -69,19 +68,18 @@ decl_module! {
 			<DIDs<T>>::insert(sender.clone(), (sign_key, box_key, doc_ref));
 			// deposit an event that the DID has been created
 			Self::deposit_event(RawEvent::DidCreated(sender.clone()));
-            Ok(())
+			Ok(())
 		}
-		
 		/// Removes a DID from chain storage, where
 		/// origin - the origin of the transaction
-        pub fn remove(origin) -> Result {
+		pub fn remove(origin) -> Result {
 			// origin of the transaction needs to be a signed sender account
 			let sender = ensure_signed(origin)?;
 			// remove DID from storage
 			<DIDs<T>>::remove(sender.clone());
 			// deposit an event that the DID has been removed
 			Self::deposit_event(RawEvent::DidRemoved(sender.clone()));
-            Ok(())
+			Ok(())
 		}
 	}
 }
@@ -89,7 +87,6 @@ decl_module! {
 decl_storage! {
 	trait Store for Module<T: Trait> as DID {
 		// DID: account-id -> (public-signing-key, public-encryption-key, did-reference?)
-		DIDs get(dids): map T::AccountId => (T::PublicSigningKey, T::PublicBoxKey, Option<Vec<u8>>);
+		DIDs get(dids): map T::AccountId => Option<(T::PublicSigningKey, T::PublicBoxKey, Option<Vec<u8>>)>;
 	}
 }
-

--- a/runtime/src/did/tests.rs
+++ b/runtime/src/did/tests.rs
@@ -71,7 +71,11 @@ fn check_add_did() {
                 signing_key.clone(), box_key.clone(), Some(b"http://kilt.org/submit".to_vec())));
 
         assert_eq!(<DIDs<Test>>::exists(account_hash), true);
-        let did = DID::dids(account_hash.clone());
+        let did = {
+            let opt = DID::dids(account_hash.clone());
+            assert!(opt.is_some());
+            opt.unwrap()
+        };
         assert_eq!(did.0, signing_key.clone());
         assert_eq!(did.1, box_key.clone());
         assert_eq!(did.2, Some(b"http://kilt.org/submit".to_vec()));

--- a/runtime/src/error/mod.rs
+++ b/runtime/src/error/mod.rs
@@ -16,16 +16,17 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-
 //! Error: Handles errors for all other runtime modules
 
-use support::{decl_event, decl_module, Parameter };
-use runtime_primitives::traits::{ SimpleArithmetic, Member, MaybeDisplay, MaybeSerializeDebug, Bounded, As };
+use runtime_primitives::traits::{
+	As, Bounded, MaybeDisplay, MaybeSerializeDebug, Member, SimpleArithmetic,
+};
+use support::{decl_event, decl_module, Parameter};
 
 /// The error trait
 pub trait Trait: system::Trait {
-    type ErrorCode : Parameter + Member + MaybeSerializeDebug + MaybeDisplay + SimpleArithmetic + Bounded;
-    type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+	type ErrorCode: Parameter + Member + MaybeSerializeDebug + MaybeDisplay + SimpleArithmetic + Bounded;
+	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
 
 /// The error type is a tuple of error code and an error message
@@ -34,7 +35,7 @@ pub type ErrorType = (u16, &'static str);
 decl_event!(
 	/// Events for errors
 	pub enum Event<T> where <T as Trait>::ErrorCode {
-        // An error occurred
+		// An error occurred
 		ErrorOccurred(ErrorCode),
 	}
 );
@@ -51,11 +52,29 @@ decl_module! {
 
 /// Implementation of further module functions for errors
 impl<T: Trait> Module<T> {
-    
-    /// Create an error, it logs the error, deposits an error event and returns the error with its message
-    pub fn error(error_type: ErrorType) -> Result<(), &'static str> {
-        ::runtime_io::print(error_type.1);
-        Self::deposit_event(RawEvent::ErrorOccurred(T::ErrorCode::sa(error_type.0.into())));
-        return Err(error_type.1);
-    }
+	/// Create an error, it logs the error, deposits an error event and returns the error with its message
+	pub fn error(error_type: ErrorType) -> Result<(), &'static str> {
+		::runtime_io::print(error_type.1);
+		Self::deposit_event(RawEvent::ErrorOccurred(T::ErrorCode::sa(
+			error_type.0.into(),
+		)));
+		return Err(error_type.1);
+	}
+
+	/// Create an error, it logs the error, deposits an error event and returns the error message
+	pub fn deposit_err(error_type: ErrorType) -> &'static str {
+		::runtime_io::print(error_type.1);
+		Self::deposit_event(RawEvent::ErrorOccurred(T::ErrorCode::sa(
+			error_type.0.into(),
+		)));
+		error_type.1
+	}
+
+	pub fn ok_or_deposit_err<S>(opt: Option<S>, error_type: ErrorType) -> Result<S, &'static str> {
+		if let Some(s) = opt {
+			Ok(s)
+		} else {
+			Err(Self::deposit_err(error_type))
+		}
+	}
 }

--- a/runtime/wasm/Cargo.lock
+++ b/runtime/wasm/Cargo.lock
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node-runtime"
-version = "0.20.0"
+version = "0.22.0"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node-runtime-wasm"
-version = "0.20.0"
+version = "0.22.0"
 dependencies = [
- "mashnet-node-runtime 0.20.0",
+ "mashnet-node-runtime 0.22.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://github.com/KILTprotocol/ticket/issues/304
Fixes https://github.com/KILTprotocol/ticket/issues/222
The return value for queries where the query does not match anything is defined as follows in substrate:
a. If the return type is an Option or wrapped in an option, return `Option<null>`
b. If the return type is not an Option, return the fallback value, which defaults to a Hex zero value of the appropriate length (`0x00000...`)

So far, we were relying on fallback values, but these make results hard to interpret in the SDK ([see this issue, for example](https://github.com/KILTprotocol/sdk-js/pull/218)). 
This set of changes wraps return values in an Option where query methods were relying on fallback values. 
As an example, `ctype.ctypes()` will now return an `Option<AccountID>`. When the Ctype hash provided is not stored on chain, the `Option<null>` returned will will be decoded to `null` by `.toJSON()`, while the result of a successful query is decoded directly to the account address string. 

These are non-breaking changes w/r/t the SDK. Changes to reflect the new return types are proposed in https://github.com/KILTprotocol/sdk-js/pull/235

## How to test:
In addition to unit tests:
1. (Re)build node and runtime
2. purge chain
3. Clone the SDK and run the following test file with yarn jest filename:
```
import getCached from './blockchainApiConnection'

test('query ctype', async () => {
  await expect(
    getCached()
      .then(bc => bc.api.query.ctype.cTYPEs('0x1235435'))
      .then(r => r.toJSON())
  ).resolves.toBeNull()
})

test('attestations', async () => {
  await expect(
    getCached()
      .then(bc => bc.api.query.attestation.attestations('0x1235435'))
      .then(r => r.toJSON())
  ).resolves.toBeNull()
})

test('delegations', async () => {
  await expect(
    getCached()
      .then(bc => bc.api.query.delegation.delegations('0x12309734'))
      .then(r => r.toJSON())
  ).resolves.toBeNull()
})

test('delegation root', async () => {
  await expect(
    getCached()
      .then(bc => bc.api.query.delegation.root('0x12309734'))
      .then(r => r.toJSON())
  ).resolves.toBeNull()
})

test('did', async () => {
  await expect(
    getCached()
      .then(bc => bc.api.query.did.dIDs('0x12309734'))
      .then(r => r.toJSON())
  ).resolves.toBeNull()
})

afterAll(async () => {
  const bc = await getCached()
  return bc.api.disconnect()
})
```

## Checklist:

- [x] I have checked that the SDK is compatible with the Option return values
- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
