### PR TITLE
feat: add alice & bob to endowed identities on dev

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -69,7 +69,9 @@ impl Alternative {
                 ], vec![
                     // Dev Faucet account
                     // Seed phrase: "receive clutch item involve chaos clutch furnace arrest claw isolate okay together"
-                    x25519::Public::from_raw(hex!("edd46b726279b53ea67dee9eeca1d8193de4d78e7e729a6d11a8dea59905f95e"))
+                    x25519::Public::from_raw(hex!("edd46b726279b53ea67dee9eeca1d8193de4d78e7e729a6d11a8dea59905f95e")),
+                    account_key("Alice"),
+                    account_key("Bob")
                 ],
                     account_key("Alice"),
                 ),


### PR DESCRIPTION
fixes https://github.com/KILTprotocol/ticket/issues/308
With this change, identities Alice and Bob are token holders on any fresh dev chain. With this, we can test things that require more than one token holding identity without relying on transferring tokens from the faucet.
This, for example, makes SDK testing easier and faster and more reliable.

## How to test:
build and purge, then run the following test in the SDK:
```
import { Identity } from "."
import { getBalance } from "./balance/Balance.chain"
import BN = require("bn.js")
import getCached from "./blockchainApiConnection"

test('Bob', async() => {
    const bobby = Identity.buildFromURI('//Bob')
    const balance = await getBalance(bobby.address)
    expect(balance.gt(new BN(0))).toBeTruthy()
})

test('Alice', async() => {
    const alice = Identity.buildFromURI('//Alice')
    const balance = await getBalance(alice.address)
    expect(balance.gt(new BN(0))).toBeTruthy()
})

afterAll(async()=> {await getCached().then(bc=>bc.api.disconnect())})
```

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
