### PR TITLE
feature: faster docker image creation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 .github
 task-definition*
+**/target

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,5 @@
 task-definition*
 **/target
 docker-compose.yml
-LICENSE
 Dockerfile
 task-definition*
-README*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 .git
 .github
+.gitignore
 task-definition*
 **/target
+docker-compose.yml
+LICENSE
+Dockerfile
+task-definition*
+README*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM rustlang/rust:nightly as builder
-
-WORKDIR /build
-
-RUN apt-get -y update && \
-	apt-get install -y --no-install-recommends \
-	clang
+# the WASM build of the runtime is completely indepedent 
+# we can avoid cache invalidations by running it in an extra container
+FROM rustlang/rust:nightly as wasm_builder
 
 # install wasm toolchain for polkadot
 RUN rustup target add wasm32-unknown-unknown --toolchain nightly
@@ -16,6 +12,7 @@ RUN cargo +nightly install --git https://github.com/alexcrichton/wasm-gc
 # show backtraces
 ENV RUST_BACKTRACE 1
 
+## not sure which of theses ENV are actually needed for this step
 #compiler ENV
 ENV CC gcc
 ENV CXX g++
@@ -24,11 +21,60 @@ ENV CXX g++
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-COPY . /build
+# Copy runtime library files
+COPY ./runtime/Cargo.lock ./runtime/Cargo.toml ./runtime/
+COPY ./runtime/src ./runtime/src
+# Copy WASM build crate files
+COPY ./runtime/wasm/build.sh ./runtime/wasm/Cargo.lock ./runtime/wasm/Cargo.toml ./runtime/wasm/
+COPY ./runtime/wasm/src ./runtime/wasm/src
 
-RUN /bin/bash scripts/build.sh
+# get build script and build
+COPY ./scripts/build.sh /scripts/build.sh
+RUN /bin/bash /scripts/build.sh
 
+# this container builds the mashnet-node binary from source files, the runtime library and the WASM file built previously
+FROM rustlang/rust:nightly as builder
+
+WORKDIR /build
+
+# install clang
+RUN apt-get -y update && \
+	apt-get install -y --no-install-recommends \
+	clang
+
+# show backtraces
+ENV RUST_BACKTRACE 1
+
+## not sure which of theses ENV are actually needed for this step
+#compiler ENV
+ENV CC gcc
+ENV CXX g++
+
+#snapcraft ENV
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# to avoid early cache invalidation, we build only dependencies first. For this we create fresh crates we are going to overwrite.
+RUN USER=root cargo init --bin --name=mashnet-node
+RUN USER=root cargo new --lib --name=mashnet-node-runtime runtime
+# overwrite cargo.toml with real files
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY ./runtime/Cargo.toml ./runtime/Cargo.lock ./runtime/
+
+# build depedencies (and bogus source files)
 RUN cargo build --release
+
+# remove bogus build (but keep depedencies)
+RUN cargo clean --release -p mashnet-node-runtime
+
+# copy everything over (cache invalidation will happen here)
+COPY . /build
+# get wasm built in previous step
+COPY --from=wasm_builder /runtime/wasm/target/wasm32-unknown-unknown/release ./runtime/wasm/target/wasm32-unknown-unknown/release
+# build source again, dependencies are already built
+RUN cargo build --release
+
+# test
 RUN cargo test --release -p mashnet-node-runtime
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # the WASM build of the runtime is completely indepedent 
 # we can avoid cache invalidations by running it in an extra container
-FROM rustlang/rust:nightly as wasm_builder
+# FIXME: We need to enfoce a specific nighlty version, since the mashnet node doesn't compile with the newest nightly. Nightlies before (and including) nightly-2020-05-14 are working.
+FROM rustlang/rust@sha256:9ac425a47e25a7a5dac999362b89de2b91b21ce70c557a409c46280393f7b1f1 as wasm_builder
 
 # install wasm toolchain for polkadot
 RUN rustup target add wasm32-unknown-unknown --toolchain nightly
@@ -33,7 +34,7 @@ COPY ./scripts/build.sh /scripts/build.sh
 RUN /bin/bash /scripts/build.sh
 
 # this container builds the mashnet-node binary from source files, the runtime library and the WASM file built previously
-FROM rustlang/rust:nightly as builder
+FROM rustlang/rust@sha256:9ac425a47e25a7a5dac999362b89de2b91b21ce70c557a409c46280393f7b1f1 as builder
 
 WORKDIR /build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,10 @@
-FROM ubuntu:xenial as builder
+FROM rustlang/rust:nightly as builder
 
 WORKDIR /build
 
-# install tools and dependencies
-RUN apt -y update && \
-	apt install -y --no-install-recommends \
-	software-properties-common curl git file binutils binutils-dev snapcraft \
-	make cmake ca-certificates g++ zip dpkg-dev python rhash rpm openssl gettext\
-	build-essential pkg-config libssl-dev libudev-dev ruby-dev time clang
-
-# install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-# rustup directory
-ENV PATH /root/.cargo/bin:$PATH
-
-# setup rust beta and nightly channel's
-RUN rustup install nightly
-RUN rustup install stable
+RUN apt-get -y update && \
+	apt-get install -y --no-install-recommends \
+	clang
 
 # install wasm toolchain for polkadot
 RUN rustup target add wasm32-unknown-unknown --toolchain nightly
@@ -28,11 +15,6 @@ RUN cargo +nightly install --git https://github.com/alexcrichton/wasm-gc
 
 # show backtraces
 ENV RUST_BACKTRACE 1
-
-# cleanup
-RUN apt autoremove -y
-RUN apt clean -y
-RUN rm -rf /tmp/* /var/tmp/*
 
 #compiler ENV
 ENV CC gcc
@@ -50,12 +32,12 @@ RUN cargo build --release
 RUN cargo test --release -p mashnet-node-runtime
 
 
-FROM ubuntu:xenial
+FROM debian:stretch
 
 WORKDIR /runtime
 
-RUN apt -y update && \
-	apt install -y --no-install-recommends \
+RUN apt-get -y update && \
+	apt-get install -y --no-install-recommends \
 	openssl \
 	curl \
 	libssl-dev dnsutils

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   dev-node:
     build: .
+    image: local/mashnet-node
     command: ./target/release/mashnet-node --dev --ws-port 9944 --ws-external
     ports:
       - 9944:9944

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,11 @@ services:
     command: ./target/release/mashnet-node --dev --ws-port 9944 --ws-external
     ports:
       - 9944:9944
+  sdk:
+    build:
+      context: https://github.com/KILTprotocol/sdk-js.git#rf-docker-compose
+    command: yarn test:integration
+    environment:
+      WS_HOST: ws://dev-node:9944
+    links:
+      - dev-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 9944:9944
   sdk:
     build:
-      context: https://github.com/KILTprotocol/sdk-js.git#rf-docker-compose
+      context: https://github.com/KILTprotocol/sdk-js.git
     command: yarn test:integration
     environment:
       WS_HOST: ws://dev-node:9944

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 9944:9944
   sdk:
     build:
-      context: https://github.com/KILTprotocol/sdk-js.git
+      context: https://github.com/KILTprotocol/sdk-js.git#develop
     command: yarn test:integration
     environment:
       WS_HOST: ws://dev-node:9944

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+
+services:
+  dev-node:
+    build: .
+    command: ./target/release/mashnet-node --dev --ws-port 9944 --ws-external
+    ports:
+      - 9944:9944


### PR DESCRIPTION
## relates to https://github.com/KILTprotocol/ticket/issues/415 ; cherry-picked from KILTprotocol/mashnet-node#80
Speeds up docker builds by using a rust-nightly image, thus skipping the rust installation bit.
Also compiles dependencies in separate steps to avoid cache invalidation by source file changes.
A `docker-compose.yml` is included to quickly spin up a dev node on port `9944` with a single `docker-compose up dev-node`. You can also run sdk integration tests against your local code with `docker-compose run sdk yarn test:integration` !

## How to test:
build and run the image with `docker-compose build` and use it. Run integration tests against it with `docker-compose run sdk yarn test:integration`.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
