### PR TITLE
publishing dev images on dockerhub

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -151,10 +151,10 @@ jobs:
     - name: Tag and push dev image to Docker Hub
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        SOURCE_IMAGE: $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
         DOCKER_REPOSITORY: kiltprotocol/mashnet-node
         DOCKER_IMAGE_TAG: develop
       run: |
+        SOURCE_IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
         docker pull $SOURCE_IMAGE
         docker tag $SOURCE_IMAGE $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG
         docker push $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -5,6 +5,10 @@ on:
     branches: 
       - develop
 
+env:
+  ECR_REPOSITORY: kilt/prototype-chain
+  ECR_IMAGE_TAG: latest-develop
+
 jobs:
   build:
 
@@ -29,8 +33,6 @@ jobs:
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: kilt/prototype-chain
-        CACHE_IMAGE_TAG: latest-develop
         CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
       run: |
         docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
@@ -39,15 +41,15 @@ jobs:
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
           .
-        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG || true
+        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG || true
         docker build \
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG \
-          -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
           .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG
-        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG"
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
 
     - name: (Alice) Fill in the new image ID in the Amazon ECS task definition
       id: task-def-alice
@@ -147,10 +149,11 @@ jobs:
 
     - name: Tag and push dev image to Docker Hub
       env:
-        SOURCE_IMAGE: ${{ jobs.build.steps.build-image.outputs.image }}
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        SOURCE_IMAGE: $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
         DOCKER_REPOSITORY: kiltprotocol/mashnet-node
-        IMAGE_TAG: develop
+        DOCKER_IMAGE_TAG: develop
       run: |
         docker pull $SOURCE_IMAGE
-        docker tag $SOURCE_IMAGE $DOCKER_REPOSITORY:$IMAGE_TAG
-        docker push $DOCKER_REPOSITORY:$IMAGE_TAG
+        docker tag $SOURCE_IMAGE $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG
+        docker push $DOCKER_REPOSITORY:$DOCKER_IMAGE_TAG

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -4,128 +4,129 @@ on:
   push:
     branches: 
       - develop
+      - publish-dev-image
 
 env:
   ECR_REPOSITORY: kilt/prototype-chain
   ECR_IMAGE_TAG: latest-develop
 
 jobs:
-  build:
+  # build:
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v1
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
+  #   - name: Configure AWS credentials
+  #     uses: aws-actions/configure-aws-credentials@v1
+  #     with:
+  #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #       aws-region: eu-central-1
 
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+  #   - name: Login to Amazon ECR
+  #     id: login-ecr
+  #     uses: aws-actions/amazon-ecr-login@v1
 
-    - name: Build, tag, and push image to Amazon ECR
-      id: build-image
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
-      run: |
-        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
-        docker build \
-          --target builder \
-          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-          -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-          .
-        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG || true
-        docker build \
-          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
-          -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
-          .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
-        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
+  #   - name: Build, tag, and push image to Amazon ECR
+  #     id: build-image
+  #     env:
+  #       ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+  #       CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
+  #     run: |
+  #       docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
+  #       docker build \
+  #         --target builder \
+  #         --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+  #         -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+  #         .
+  #       docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG || true
+  #       docker build \
+  #         --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+  #         --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
+  #         -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
+  #         .
+  #       docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG
+  #       docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
+  #       echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
 
-    - name: (Alice) Fill in the new image ID in the Amazon ECS task definition
-      id: task-def-alice
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition-alice.json
-        container-name: devnet-node
-        image: ${{ steps.build-image.outputs.image }}
+  #   - name: (Alice) Fill in the new image ID in the Amazon ECS task definition
+  #     id: task-def-alice
+  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
+  #     with:
+  #       task-definition: task-definition-alice.json
+  #       container-name: devnet-node
+  #       image: ${{ steps.build-image.outputs.image }}
 
-    - name: (Alice) Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def-alice.outputs.task-definition }}
-        service: bootnode-alice
-        cluster: kilt-devnet
-        wait-for-service-stability: true
+  #   - name: (Alice) Deploy Amazon ECS task definition
+  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+  #     with:
+  #       task-definition: ${{ steps.task-def-alice.outputs.task-definition }}
+  #       service: bootnode-alice
+  #       cluster: kilt-devnet
+  #       wait-for-service-stability: true
 
-    - name: (Bob) Fill in the new image ID in the Amazon ECS task definition
-      id: task-def-bob
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition-bob.json
-        container-name: devnet-node
-        image: ${{ steps.build-image.outputs.image }}
+  #   - name: (Bob) Fill in the new image ID in the Amazon ECS task definition
+  #     id: task-def-bob
+  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
+  #     with:
+  #       task-definition: task-definition-bob.json
+  #       container-name: devnet-node
+  #       image: ${{ steps.build-image.outputs.image }}
 
-    - name: (Bob) Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def-bob.outputs.task-definition }}
-        service: bootnode-bob
-        cluster: kilt-devnet
-        wait-for-service-stability: true
+  #   - name: (Bob) Deploy Amazon ECS task definition
+  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+  #     with:
+  #       task-definition: ${{ steps.task-def-bob.outputs.task-definition }}
+  #       service: bootnode-bob
+  #       cluster: kilt-devnet
+  #       wait-for-service-stability: true
 
-    - name: (Charlie) Fill in the new image ID in the Amazon ECS task definition
-      id: task-def-charlie
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition-charlie.json
-        container-name: devnet-charlie
-        image: ${{ steps.build-image.outputs.image }}
+  #   - name: (Charlie) Fill in the new image ID in the Amazon ECS task definition
+  #     id: task-def-charlie
+  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
+  #     with:
+  #       task-definition: task-definition-charlie.json
+  #       container-name: devnet-charlie
+  #       image: ${{ steps.build-image.outputs.image }}
 
-    - name: (Charlie) Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def-charlie.outputs.task-definition }}
-        service: bootnode-charlie
-        cluster: kilt-devnet
-        wait-for-service-stability: true
+  #   - name: (Charlie) Deploy Amazon ECS task definition
+  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+  #     with:
+  #       task-definition: ${{ steps.task-def-charlie.outputs.task-definition }}
+  #       service: bootnode-charlie
+  #       cluster: kilt-devnet
+  #       wait-for-service-stability: true
 
-    - name: (Full) Fill in the new image ID in the Amazon ECS task definition
-      id: task-def-full
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition-full.json
-        container-name: devnet-node
-        image: ${{ steps.build-image.outputs.image }}
+  #   - name: (Full) Fill in the new image ID in the Amazon ECS task definition
+  #     id: task-def-full
+  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
+  #     with:
+  #       task-definition: task-definition-full.json
+  #       container-name: devnet-node
+  #       image: ${{ steps.build-image.outputs.image }}
 
-    - name: (Full) Deploy Amazon ECS task definition
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def-full.outputs.task-definition }}
-        service: full-nodes
-        cluster: kilt-devnet
-        wait-for-service-stability: true
+  #   - name: (Full) Deploy Amazon ECS task definition
+  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+  #     with:
+  #       task-definition: ${{ steps.task-def-full.outputs.task-definition }}
+  #       service: full-nodes
+  #       cluster: kilt-devnet
+  #       wait-for-service-stability: true
 
-    - name: Purge data in demo services
-      env:
-        SERVICES_SECRET: ${{ secrets.SERVICES_SECRET }}
-      run: |
-        curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/ctype
-        curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/messaging
-        curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/contacts
+  #   - name: Purge data in demo services
+  #     env:
+  #       SERVICES_SECRET: ${{ secrets.SERVICES_SECRET }}
+  #     run: |
+  #       curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/ctype
+  #       curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/messaging
+  #       curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/contacts
 
   publish_to_docker:
     name: Publish develop image to docker
-    needs: build
+    # needs: build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -127,7 +127,8 @@ jobs:
     name: Publish develop image to docker
     needs: build
     runs-on: ubuntu-latest
-
+    # this job pulls the develop image just built from our private ECR repository,
+    # then pushes it to the public docker repository under a dedicated tag
     steps:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -120,3 +120,37 @@ jobs:
         curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/ctype
         curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/messaging
         curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/contacts
+
+  publish_to_docker:
+    name: Publish develop image to docker
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+      
+    - name: Login to Docker Hub
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+      run: |
+        echo $DOCKER_PASS | docker login --username=$DOCKER_USER --password-stdin
+
+    - name: Tag and push dev image to Docker Hub
+      env:
+        SOURCE_IMAGE: ${{ jobs.build.steps.build-image.outputs.image }}
+        DOCKER_REPOSITORY: kiltprotocol/mashnet-node
+        IMAGE_TAG: develop
+      run: |
+        docker pull $SOURCE_IMAGE
+        docker tag $SOURCE_IMAGE $DOCKER_REPOSITORY:$IMAGE_TAG
+        docker push $DOCKER_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -4,129 +4,128 @@ on:
   push:
     branches: 
       - develop
-      - publish-dev-image
 
 env:
   ECR_REPOSITORY: kilt/prototype-chain
   ECR_IMAGE_TAG: latest-develop
 
 jobs:
-  # build:
+  build:
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@v1
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
 
-  #   - name: Configure AWS credentials
-  #     uses: aws-actions/configure-aws-credentials@v1
-  #     with:
-  #       aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #       aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #       aws-region: eu-central-1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
 
-  #   - name: Login to Amazon ECR
-  #     id: login-ecr
-  #     uses: aws-actions/amazon-ecr-login@v1
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
 
-  #   - name: Build, tag, and push image to Amazon ECR
-  #     id: build-image
-  #     env:
-  #       ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-  #       CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
-  #     run: |
-  #       docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
-  #       docker build \
-  #         --target builder \
-  #         --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-  #         -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-  #         .
-  #       docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG || true
-  #       docker build \
-  #         --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
-  #         --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
-  #         -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
-  #         .
-  #       docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG
-  #       docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
-  #       echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
+      run: |
+        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
+        docker build \
+          --target builder \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+          .
+        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG || true
+        docker build \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG \
+          .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG
+        echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$ECR_IMAGE_TAG"
 
-  #   - name: (Alice) Fill in the new image ID in the Amazon ECS task definition
-  #     id: task-def-alice
-  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
-  #     with:
-  #       task-definition: task-definition-alice.json
-  #       container-name: devnet-node
-  #       image: ${{ steps.build-image.outputs.image }}
+    - name: (Alice) Fill in the new image ID in the Amazon ECS task definition
+      id: task-def-alice
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-alice.json
+        container-name: devnet-node
+        image: ${{ steps.build-image.outputs.image }}
 
-  #   - name: (Alice) Deploy Amazon ECS task definition
-  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-  #     with:
-  #       task-definition: ${{ steps.task-def-alice.outputs.task-definition }}
-  #       service: bootnode-alice
-  #       cluster: kilt-devnet
-  #       wait-for-service-stability: true
+    - name: (Alice) Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def-alice.outputs.task-definition }}
+        service: bootnode-alice
+        cluster: kilt-devnet
+        wait-for-service-stability: true
 
-  #   - name: (Bob) Fill in the new image ID in the Amazon ECS task definition
-  #     id: task-def-bob
-  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
-  #     with:
-  #       task-definition: task-definition-bob.json
-  #       container-name: devnet-node
-  #       image: ${{ steps.build-image.outputs.image }}
+    - name: (Bob) Fill in the new image ID in the Amazon ECS task definition
+      id: task-def-bob
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-bob.json
+        container-name: devnet-node
+        image: ${{ steps.build-image.outputs.image }}
 
-  #   - name: (Bob) Deploy Amazon ECS task definition
-  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-  #     with:
-  #       task-definition: ${{ steps.task-def-bob.outputs.task-definition }}
-  #       service: bootnode-bob
-  #       cluster: kilt-devnet
-  #       wait-for-service-stability: true
+    - name: (Bob) Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def-bob.outputs.task-definition }}
+        service: bootnode-bob
+        cluster: kilt-devnet
+        wait-for-service-stability: true
 
-  #   - name: (Charlie) Fill in the new image ID in the Amazon ECS task definition
-  #     id: task-def-charlie
-  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
-  #     with:
-  #       task-definition: task-definition-charlie.json
-  #       container-name: devnet-charlie
-  #       image: ${{ steps.build-image.outputs.image }}
+    - name: (Charlie) Fill in the new image ID in the Amazon ECS task definition
+      id: task-def-charlie
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-charlie.json
+        container-name: devnet-charlie
+        image: ${{ steps.build-image.outputs.image }}
 
-  #   - name: (Charlie) Deploy Amazon ECS task definition
-  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-  #     with:
-  #       task-definition: ${{ steps.task-def-charlie.outputs.task-definition }}
-  #       service: bootnode-charlie
-  #       cluster: kilt-devnet
-  #       wait-for-service-stability: true
+    - name: (Charlie) Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def-charlie.outputs.task-definition }}
+        service: bootnode-charlie
+        cluster: kilt-devnet
+        wait-for-service-stability: true
 
-  #   - name: (Full) Fill in the new image ID in the Amazon ECS task definition
-  #     id: task-def-full
-  #     uses: aws-actions/amazon-ecs-render-task-definition@v1
-  #     with:
-  #       task-definition: task-definition-full.json
-  #       container-name: devnet-node
-  #       image: ${{ steps.build-image.outputs.image }}
+    - name: (Full) Fill in the new image ID in the Amazon ECS task definition
+      id: task-def-full
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition-full.json
+        container-name: devnet-node
+        image: ${{ steps.build-image.outputs.image }}
 
-  #   - name: (Full) Deploy Amazon ECS task definition
-  #     uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-  #     with:
-  #       task-definition: ${{ steps.task-def-full.outputs.task-definition }}
-  #       service: full-nodes
-  #       cluster: kilt-devnet
-  #       wait-for-service-stability: true
+    - name: (Full) Deploy Amazon ECS task definition
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def-full.outputs.task-definition }}
+        service: full-nodes
+        cluster: kilt-devnet
+        wait-for-service-stability: true
 
-  #   - name: Purge data in demo services
-  #     env:
-  #       SERVICES_SECRET: ${{ secrets.SERVICES_SECRET }}
-  #     run: |
-  #       curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/ctype
-  #       curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/messaging
-  #       curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/contacts
+    - name: Purge data in demo services
+      env:
+        SERVICES_SECRET: ${{ secrets.SERVICES_SECRET }}
+      run: |
+        curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/ctype
+        curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/messaging
+        curl -X DELETE -H "Authorization: ${SERVICES_SECRET}" https://services.devnet.kilt.io/contacts
 
   publish_to_docker:
     name: Publish develop image to docker
-    # needs: build
+    needs: build
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## part of KILTProtocol/ticket#530
On pushes to develop, the docker image built for EWS and deployed to the devnet will also be pushed to the mashnet-node repository on docker hub under a dedicated tag (currently set to `develop`)

## How to test:
the latest commit 1554634 has triggered a successful test run pushing to docker hub ([here](https://github.com/KILTprotocol/mashnet-node/actions/runs/131928883)). You can also pull the image with `kiltprotocol/mashnet-node:develop` and test it.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
