### PR TITLE
ci: cache wasm builder

### DIFF
--- a/.github/workflows/aws-dev.yml
+++ b/.github/workflows/aws-dev.yml
@@ -32,19 +32,29 @@ jobs:
         ECR_REPOSITORY: kilt/prototype-chain
         CACHE_IMAGE_TAG: latest-develop
         CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
+        CACHE_IMAGE_WASM_BUILDER_TAG: latest-develop-wasm-builder
       run: |
+        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG || true
+        docker build \
+        --target wasm_builder \
+        --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG \
+        -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
+        .
         docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
         docker build \
           --target builder \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG \
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
           .
         docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG || true
         docker build \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG \
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG \
           .
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,13 @@ jobs:
         ECR_REPOSITORY: kilt/prototype-chain
         CACHE_IMAGE_TAG: latest-develop
         CACHE_IMAGE_BUILDER_TAG: latest-develop-builder
+        CACHE_IMAGE_WASM_BUILDER_TAG: latest-develop-wasm-builder
       run: |
+        docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG || true
         docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG || true
         docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG || true
         docker build \
+          --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_WASM_BUILDER_TAG \
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_BUILDER_TAG \
           --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$CACHE_IMAGE_TAG \
           .


### PR DESCRIPTION
## no ticket
Given that we introduced another build step during building of docker images, the CI needs to be updated to reflect this change in order to benefit from reduced build times.

## How to test:
a new image will only be pushed when merging to develop; only then the build speed will increase. ~~I could make a temporary change to the workflow to trigger a build on this branch though.~~ <- can't; this would also deploy to the devnet

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
