### PR TITLE
ci: pinned base image version to avoid cache invalidation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,10 @@
 .gitignore
 task-definition*
 **/target
+**/*.rs.bk
+*.iml
+.vscode
+.editorconfig
 docker-compose.yml
 Dockerfile
-task-definition*
-**/target/
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # this container builds the mashnet-node binary from source files and the runtime library
-FROM paritytech/ci-linux:production as builder
+# pinned the version to avoid build cache invalidation
+FROM paritytech/ci-linux@sha256:7745e0c755153465fa58f4bf1117df1eb9351f445411083b4b1fb2434852f938 as builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## No Ticket
To avoid cache invalidation whenever parity publish a new version of the image we use as a base image for the builder, I pinned this image to a specific digest.

## How to test:
- [x] does it pass CI tests?

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
