### PR TITLE
feat: specifiy specific nightly channel

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,8 +5,9 @@ set -e
 echo "*** Initializing WASM build environment"
 
 if [ -z $CI_PROJECT_NAME ] ; then
-   rustup update nightly
+   rustup install nightly-2020-10-06
    rustup update stable
 fi
 
-rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-06
+rustup override set nightly-2020-10-06

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+BASEDIR=$(dirname "$0")
 set -e
 
 echo "*** Initializing WASM build environment"
@@ -10,4 +10,4 @@ if [ -z $CI_PROJECT_NAME ] ; then
 fi
 
 rustup target add wasm32-unknown-unknown --toolchain nightly-2020-10-06
-rustup override set nightly-2020-10-06
+rustup override set nightly-2020-10-06 --path $BASEDIR/..


### PR DESCRIPTION
## fixes KILTProtocol/ticket#821
Adds specific nightly version, as newer might cause issues building. This is the [officially advised](https://substrate.dev/docs/en/knowledgebase/getting-started/#rust-nightly-toolchain) version: nightly-2020-10-06

## How to test:
Use script file.
read  ~/.rustup/settings.toml
mashnet-node path should have specific nightly set as override
## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
