### PR TITLE
feat: added unit denomination to chain spec properties

### DIFF
--- a/chainspec-devnet-nonraw.json
+++ b/chainspec-devnet-nonraw.json
@@ -5,7 +5,10 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18,
+    "tokenSymbol": "KILT"
+  },
   "consensusEngine": null,
   "genesis": {
     "runtime": {

--- a/chainspec-devnet.json
+++ b/chainspec-devnet.json
@@ -5,7 +5,10 @@
   "bootNodes": [],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18,
+    "tokenSymbol": "KILT"
+  },
   "consensusEngine": null,
   "genesis": {
     "raw": {

--- a/chainspec.json
+++ b/chainspec.json
@@ -6,7 +6,10 @@
   ],
   "telemetryEndpoints": null,
   "protocolId": null,
-  "properties": null,
+  "properties": {
+    "tokenDecimals": 18,
+    "tokenSymbol": "KILT"
+  },
   "consensusEngine": null,
   "genesis": {
     "raw": {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#714

Adds dudleys changes to the chain unit properties to the actual spec files.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
