### PR TITLE
feat: add support for DID removal

### DIFF
--- a/pallets/did/src/default_weights.rs
+++ b/pallets/did/src/default_weights.rs
@@ -55,6 +55,7 @@ use sp_std::marker::PhantomData;
 pub trait WeightInfo {
 	fn submit_did_create_operation() -> Weight;
 	fn submit_did_update_operation() -> Weight;
+	fn submit_did_delete_operation() -> Weight;
 }
 
 /// Weights for did using the Substrate node and recommended hardware.
@@ -70,6 +71,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
+	fn submit_did_delete_operation() -> Weight {
+		(69_641_000_u64)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -80,6 +86,11 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(1u64))
 	}
 	fn submit_did_update_operation() -> Weight {
+		(69_641_000_u64)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(RocksDbWeight::get().reads(1u64))
+	}
+	fn submit_did_delete_operation() -> Weight {
 		(69_641_000_u64)
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 			.saturating_add(RocksDbWeight::get().reads(1u64))

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -291,6 +291,31 @@ where
 	}
 }
 
+/// A DID deletion request. It contains the following values:
+/// * The DID identifier being deleted
+/// * A counter used to protect against replay attacks
+#[derive(Clone, Decode, Debug, Encode, PartialEq)]
+pub struct DidDeletionOperation<DidIdentifier>
+where
+	DidIdentifier: Parameter + Encode + Decode + Debug,
+{
+	did: DidIdentifier,
+	tx_counter: u64,
+}
+
+impl<DidIdentifier> DidOperation<DidIdentifier> for DidDeletionOperation<DidIdentifier>
+where
+	DidIdentifier: Parameter + Encode + Decode + Debug,
+{
+	fn get_verification_key_type(&self) -> DidVerificationKeyType {
+		DidVerificationKeyType::Authentication
+	}
+
+	fn get_did(&self) -> &DidIdentifier {
+		&self.did
+	}
+}
+
 /// The details associated to a DID identity. Specifically:
 /// * The authentication key, used to authenticate DID-related operations
 /// * The key agreement key, used to encrypt data addressed to the DID subject
@@ -302,7 +327,7 @@ where
 ///   exposes
 /// * A counter used to avoid replay attacks, which is checked and updated upon
 ///   each DID-related operation
-#[derive(Clone, Decode, Encode, PartialEq)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq)]
 pub struct DidDetails {
 	auth_key: PublicVerificationKey,
 	key_agreement_key: PublicEncryptionKey,
@@ -378,7 +403,7 @@ where
 			);
 		};
 
-		// Verify that the operation counter is greater than the stored
+		// Verify that the operation counter is greater than the stored one
 		ensure!(
 			update_operation.tx_counter > new_details.last_tx_counter,
 			DidError::OperationError(OperationError::InvalidNonce)
@@ -444,6 +469,7 @@ pub mod pallet {
 	pub enum Event<T: Config> {
 		DidCreated(T::AccountId, T::DidIdentifier),
 		DidUpdated(T::AccountId, T::DidIdentifier),
+		DidDeleted(T::AccountId, T::DidIdentifier),
 	}
 
 	#[pallet::error]
@@ -546,7 +572,6 @@ pub mod pallet {
 			<Did<T>>::insert(did_identifier, did_entry);
 
 			Self::deposit_event(Event::DidCreated(sender, did_identifier.clone()));
-			//TODO: Return the real weight used
 			Ok(().into())
 		}
 
@@ -589,7 +614,46 @@ pub mod pallet {
 			<Did<T>>::insert(&did_identifier, new_did_details);
 
 			Self::deposit_event(Event::DidUpdated(sender, did_identifier));
-			//TODO: Return the real weight used
+			Ok(().into())
+		}
+
+		/// Deletes all the information associated with a DID on chain, after
+		/// verifying the signature associated with the operation. The
+		/// parameters are:
+		/// * origin: the Substrate account submitting the transaction (which
+		///   can be different from the DID subject)
+		/// * did_deletion_operation: a DidDeletionOperation which includes the
+		///   DID to deactivate
+		/// * signature: a signature over the operation that must be signed with
+		///   the authentication key associated with the new DID.
+		#[pallet::weight(<T as Config>::WeightInfo::submit_did_delete_operation())]
+		pub fn submit_did_delete_operation(
+			origin: OriginFor<T>,
+			did_deletion_operation: DidDeletionOperation<T::DidIdentifier>,
+			signature: DidSignature,
+		) -> DispatchResultWithPostInfo {
+			// origin of the transaction needs to be a signed sender account
+			let sender = ensure_signed(origin)?;
+
+			let did_identifier = did_deletion_operation.get_did();
+
+			// If specified DID does not exist, generate a DidNotPresent error.
+			let did_details = <Did<T>>::get(&did_identifier).ok_or(<Error<T>>::DidNotPresent)?;
+
+			// Verify the signature of the delete operation.
+			Self::verify_operation_signature_for_entry(&did_deletion_operation, &signature, &did_details)
+				.map_err(<Error<T>>::from)?;
+
+			// Verify that the operation counter is greater than the stored one
+			ensure!(
+				did_deletion_operation.tx_counter > did_details.last_tx_counter,
+				<Error<T>>::InvalidNonce
+			);
+
+			log::debug!("Deleting DID {:?}", did_identifier);
+			<Did<T>>::take(&did_identifier);
+
+			Self::deposit_event(Event::DidDeleted(sender, did_identifier.clone()));
 			Ok(().into())
 		}
 	}

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -651,7 +651,7 @@ pub mod pallet {
 			);
 
 			log::debug!("Deleting DID {:?}", did_identifier);
-			<Did<T>>::take(&did_identifier);
+			<Did<T>>::remove(&did_identifier);
 
 			Self::deposit_event(Event::DidDeleted(sender, did_identifier.clone()));
 			Ok(().into())

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -178,6 +178,13 @@ pub fn generate_base_did_update_operation(did: TestDidIdentifier) -> did::DidUpd
 	}
 }
 
+pub fn generate_base_did_delete_operation(did: TestDidIdentifier) -> did::DidDeletionOperation<TestDidIdentifier> {
+	DidDeletionOperation {
+		did: did,
+		tx_counter: u64::MAX,
+	}
+}
+
 pub fn generate_mock_did_details(
 	auth_key: did::PublicVerificationKey,
 	enc_key: did::PublicEncryptionKey,

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -514,7 +514,6 @@ fn check_successful_deletion() {
 	assert_eq!(ext.execute_with(|| Did::get_did(ALICE_DID)), None);
 
 	// Re-adding the same DID identifier, which should not fail.
-
 	let auth_key = get_sr25519_authentication_key(true);
 	let enc_key = get_x25519_encryption_key(true);
 	let did_creation_operation =

--- a/pallets/did/src/tests.rs
+++ b/pallets/did/src/tests.rs
@@ -483,6 +483,182 @@ fn check_equal_tx_counter_did_update() {
 	});
 }
 
+// submit_did_delete_operation
+
+#[test]
+fn check_successful_deletion() {
+	let auth_key = get_ed25519_authentication_key(true);
+	let enc_key = get_x25519_encryption_key(true);
+
+	let did_details = generate_mock_did_details(did::PublicVerificationKey::from(auth_key.public()), enc_key);
+
+	// Update all keys, URL endpoint and tx counter. No keys are removed in this
+	// test
+	let did_delete_operation = generate_base_did_delete_operation(ALICE_DID);
+
+	// Generate signature using the old authentication key
+	let signature = auth_key.sign(did_delete_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default()
+		.with_dids(vec![(ALICE_DID, did_details.clone())])
+		.build();
+
+	ext.execute_with(|| {
+		assert_ok!(Did::submit_did_delete_operation(
+			Origin::signed(DEFAULT_ACCOUNT),
+			did_delete_operation.clone(),
+			did::DidSignature::from(signature),
+		));
+	});
+
+	assert_eq!(ext.execute_with(|| Did::get_did(ALICE_DID)), None);
+
+	// Re-adding the same DID identifier, which should not fail.
+
+	let auth_key = get_sr25519_authentication_key(true);
+	let enc_key = get_x25519_encryption_key(true);
+	let did_creation_operation =
+		generate_base_did_creation_operation(ALICE_DID, did::PublicVerificationKey::from(auth_key.public()), enc_key);
+
+	let signature = auth_key.sign(did_creation_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default().build();
+
+	ext.execute_with(|| {
+		assert_ok!(Did::submit_did_create_operation(
+			Origin::signed(DEFAULT_ACCOUNT),
+			did_creation_operation.clone(),
+			did::DidSignature::from(signature),
+		));
+	});
+}
+
+#[test]
+fn check_did_not_present_deletion() {
+	let auth_key = get_ed25519_authentication_key(true);
+
+	// Update all keys, URL endpoint and tx counter. No keys are removed in this
+	// test
+	let did_delete_operation = generate_base_did_delete_operation(ALICE_DID);
+
+	// Generate signature using the old authentication key
+	let signature = auth_key.sign(did_delete_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default().build();
+
+	ext.execute_with(|| {
+		assert_noop!(
+			Did::submit_did_delete_operation(
+				Origin::signed(DEFAULT_ACCOUNT),
+				did_delete_operation.clone(),
+				did::DidSignature::from(signature),
+			),
+			did::Error::<Test>::DidNotPresent
+		);
+	});
+}
+
+#[test]
+fn check_invalid_signature_format_did_deletion() {
+	let auth_key = get_ed25519_authentication_key(true);
+	let enc_key = get_x25519_encryption_key(true);
+	// Using an Sr25519 key where an Ed25519 is expected
+	let invalid_key = get_sr25519_authentication_key(true);
+	let mock_did = generate_mock_did_details(did::PublicVerificationKey::from(auth_key.public()), enc_key);
+	// DID update contains auth_key, but signature is generated using invalid_key
+	let did_deletion_operation = generate_base_did_delete_operation(ALICE_DID);
+
+	let signature = invalid_key.sign(did_deletion_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default().with_dids(vec![(ALICE_DID, mock_did)]).build();
+
+	ext.execute_with(|| {
+		assert_noop!(
+			Did::submit_did_delete_operation(
+				Origin::signed(DEFAULT_ACCOUNT),
+				did_deletion_operation.clone(),
+				did::DidSignature::from(signature),
+			),
+			did::Error::<Test>::InvalidSignatureFormat
+		);
+	});
+}
+
+#[test]
+fn check_invalid_signature_did_deletion() {
+	let auth_key = get_sr25519_authentication_key(true);
+	let enc_key = get_x25519_encryption_key(true);
+	// Using an Sr25519 key as expected, but from a different seed (default = false)
+	let alternative_key = get_sr25519_authentication_key(false);
+	let mock_did = generate_mock_did_details(PublicVerificationKey::from(auth_key.public()), enc_key);
+	let did_delete_operation = generate_base_did_delete_operation(ALICE_DID);
+
+	let signature = alternative_key.sign(did_delete_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default().with_dids(vec![(ALICE_DID, mock_did)]).build();
+
+	ext.execute_with(|| {
+		assert_noop!(
+			Did::submit_did_delete_operation(
+				Origin::signed(DEFAULT_ACCOUNT),
+				did_delete_operation.clone(),
+				did::DidSignature::from(signature),
+			),
+			did::Error::<Test>::InvalidSignature
+		);
+	});
+}
+
+#[test]
+fn check_smaller_tx_counter_did_deletion() {
+	let auth_key = get_sr25519_authentication_key(true);
+	let enc_key = get_x25519_encryption_key(true);
+	let mut mock_did = generate_mock_did_details(PublicVerificationKey::from(auth_key.public()), enc_key);
+	mock_did.last_tx_counter = 1;
+	let mut did_delete_operation = generate_base_did_delete_operation(ALICE_DID);
+	did_delete_operation.tx_counter = 0;
+
+	let signature = auth_key.sign(did_delete_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default().with_dids(vec![(ALICE_DID, mock_did)]).build();
+
+	ext.execute_with(|| {
+		assert_noop!(
+			Did::submit_did_delete_operation(
+				Origin::signed(DEFAULT_ACCOUNT),
+				did_delete_operation.clone(),
+				did::DidSignature::from(signature),
+			),
+			did::Error::<Test>::InvalidNonce
+		);
+	});
+}
+
+#[test]
+fn check_equal_tx_counter_did_deletion() {
+	let auth_key = get_sr25519_authentication_key(true);
+	let enc_key = get_x25519_encryption_key(true);
+	let mut mock_did = generate_mock_did_details(PublicVerificationKey::from(auth_key.public()), enc_key);
+	mock_did.last_tx_counter = 1;
+	let mut did_delete_operation = generate_base_did_delete_operation(ALICE_DID);
+	did_delete_operation.tx_counter = mock_did.last_tx_counter;
+
+	let signature = auth_key.sign(did_delete_operation.encode().as_ref());
+
+	let mut ext = ExtBuilder::default().with_dids(vec![(ALICE_DID, mock_did)]).build();
+
+	ext.execute_with(|| {
+		assert_noop!(
+			Did::submit_did_delete_operation(
+				Origin::signed(DEFAULT_ACCOUNT),
+				did_delete_operation.clone(),
+				did::DidSignature::from(signature),
+			),
+			did::Error::<Test>::InvalidNonce
+		);
+	});
+}
+
 // Internal function: verify_did_operation_signature
 
 #[test]


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1182

Add support to delete all the information associated with a DID from the chain.

## How to test:

### With Cargo

Run `cargo test`.

### With Polkadot-JS apps

1. Follow the steps in https://github.com/KILTprotocol/mashnet-node/pull/127 to create a new test identity and test DID
2. Open the UI to invoke a `submitDidDeleteOperation` extrinsic
3. `did: DIDIdentifier` -> select the test account created
4. `tx_counter: U64` -> insert `1`
5. `signature: DidSignature` -> select `Ed25519` and value `0x1901e750f8fb18486858ac59136e6448974afb1b3da4adb184e7453aa2fe4352f210a1e57a12c536d88ccbd0b0569c9cbf99fb6d4623e1071c0fb98087d6dc07` (this is the signature over the encoded delete operation)

Now, if you try to re-execute the same operation, the extrinsic will fail with a `did.DidNotPresent` error.

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [x] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
