### PR TITLE
DID call (based on develop)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10359,13 +10359,13 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#13a07b4b637b6e25397db7fcd62d8b93eeae76ac"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a3d51ad6abbc408b03ea962062bfcc959b438a318d7d4bedd181e1effd0610"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "build-helper",
  "cargo_metadata",
- "sp-maybe-compressed-blob",
  "tempfile",
  "toml",
  "walkdir",
@@ -10375,13 +10375,13 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a3d51ad6abbc408b03ea962062bfcc959b438a318d7d4bedd181e1effd0610"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#13a07b4b637b6e25397db7fcd62d8b93eeae76ac"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "build-helper",
  "cargo_metadata",
+ "sp-maybe-compressed-blob",
  "tempfile",
  "toml",
  "walkdir",

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -43,7 +43,7 @@ use frame_support::{ensure, storage::types::StorageMap, Parameter};
 use frame_system::{self, ensure_signed};
 use sp_core::{ed25519, sr25519};
 use sp_runtime::traits::Verify;
-use sp_std::{collections::btree_set::BTreeSet, convert::TryFrom, fmt::Debug, prelude::Clone, str, vec::Vec};
+use sp_std::{collections::btree_set::BTreeSet, boxed::Box, convert::TryFrom, fmt::Debug, prelude::Clone, str, vec::Vec};
 
 pub use pallet::*;
 
@@ -843,13 +843,13 @@ pub mod pallet {
 		#[pallet::weight(10)]
 		pub fn submit_did_call(
 			origin: OriginFor<T>,
-			did_call: DidCallOperation<T>,
+			did_call: Box<DidCallOperation<T>>,
 			signature: DidSignature,
 		) -> DispatchResultWithPostInfo {
 			ensure_signed(origin.clone())?;
 
 			// Verify the signature and the nonce of the delete operation.
-			Self::verify_did_operation_signature(&did_call, &signature).map_err(<Error<T>>::from)?;
+			Self::verify_did_operation_signature(&*did_call, &signature).map_err(<Error<T>>::from)?;
 
 			let res = did_call.call.dispatch(origin);
 

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -75,6 +75,7 @@ impl frame_system::Config for Test {
 
 impl did::Config for Test {
 	type Event = ();
+	type Call = Call;
 	type WeightInfo = ();
 	type DidIdentifier = AccountId;
 }

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -80,6 +80,15 @@ impl did::Config for Test {
 	type DidIdentifier = AccountId;
 }
 
+impl DeriveDidVerificationType for Call {
+	fn verification_type(&self) -> Option<DidVerificationKeyType> {
+		match self {
+			Call::System(_) => None,
+			Call::Did(_) => Some(DidVerificationKeyType::Authentication),
+		}
+	}
+}
+
 pub type TestDidIdentifier = <Test as did::Config>::DidIdentifier;
 
 pub const DEFAULT_ACCOUNT: AccountId = AccountId::new([0u8; 32]);

--- a/runtimes/parachain/src/lib.rs
+++ b/runtimes/parachain/src/lib.rs
@@ -743,6 +743,17 @@ impl did::Config for Runtime {
 	type DidIdentifier = AccountId;
 }
 
+impl did::DeriveDidVerificationType for Call {
+	fn verification_type(&self) -> Option<did::DidVerificationKeyType> {
+		match self {
+			Call::Did(_) => Some(did::DidVerificationKeyType::Authentication),
+			Call::Ctype(_) => Some(did::DidVerificationKeyType::Authentication),
+			Call::Delegation(_) => Some(did::DidVerificationKeyType::Authentication),
+			_ => None,
+		}
+	}
+}
+
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,

--- a/runtimes/parachain/src/lib.rs
+++ b/runtimes/parachain/src/lib.rs
@@ -738,6 +738,7 @@ impl delegation::Config for Runtime {
 impl did::Config for Runtime {
 	/// The ubiquitous event type.
 	type Event = Event;
+	type Call = Call;
 	type WeightInfo = ();
 	type DidIdentifier = AccountId;
 }

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -347,6 +347,7 @@ impl frame_support::traits::OnRuntimeUpgrade for DelegationStructRuntimeUpgrade 
 impl did::Config for Runtime {
 	/// The ubiquitous event type.
 	type Event = Event;
+	type Call = Call;
 	type WeightInfo = ();
 	type DidIdentifier = AccountId;
 }

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -352,6 +352,17 @@ impl did::Config for Runtime {
 	type DidIdentifier = AccountId;
 }
 
+impl did::DeriveDidVerificationType for Call {
+	fn verification_type(&self) -> Option<did::DidVerificationKeyType> {
+		match self {
+			Call::Did(_) => Some(did::DidVerificationKeyType::Authentication),
+			Call::Ctype(_) => Some(did::DidVerificationKeyType::Authentication),
+			Call::Delegation(_) => Some(did::DidVerificationKeyType::Authentication),
+			_ => None,
+		}
+	}
+}
+
 pub struct PortableGabiRemoval;
 impl frame_support::traits::OnRuntimeUpgrade for PortableGabiRemoval {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1270

A call signed by an DID can get executed by anyone.

TODO:

- who is the origin? Currently the sender. That makes no sense. The did should be the origin?

## types

<details>
{
  "Balance": "u128",
  "PublicSigningKey": "Hash",
  "PublicBoxKey": "Hash",
  "BlockNumber": "u64",
  "AmountOf": "i128",
  "Address": "MultiAddress",
  "Index": "u64",
  "Permissions": "u32",
  "DelegationNodeId": "Hash",
  "DelegationNode": {
    "rootId": "DelegationNodeId",
    "parent": "Option<DelegationNodeId>",
    "owner": "AccountId",
    "permissions": "Permissions",
    "revoked": "bool"
  },
  "DelegationRoot": {
    "ctypeHash": "Hash",
    "owner": "AccountId",
    "revoked": "bool"
  },
  "Attestation": {
    "ctypeHash": "Hash",
    "attester": "AccountId",
    "delegationId": "Option<DelegationNodeId>",
    "revoked": "bool"
  },
  "XCurrencyId": {
    "chainId": "ChainId",
    "currencyId": "Vec<u8>"
  },
  "ChainId": {
    "_enum": {
      "RelayChain": "Null",
      "ParaChain": "ParaId"
    }
  },
  "CurrencyIdOf": "CurrencyId",
  "CurrencyId": {
    "_enum": {
      "Dot": 0,
      "Ksm": 1,
      "Kilt": 2
    }
  },
  "DidIdentifier": "AccountId",
  "DidVerificationKeyType": {
    "_enum": [
      "Authentication",
      "CapabilityDelegation",
      "CapabilityInvocation",
      "AssertionMethod"
    ]
  },
  "DidEncryptionKeyType": {
    "_enum": [
      "KeyAgreement"
    ]
  },
  "PublicVerificationKey": {
    "_enum": {
      "Ed25519": "[u8; 32]",
      "Sr25519": "[u8; 32]"
    }
  },
  "DidSignature": {
    "_enum": {
      "Ed25519": "Ed25519Signature",
      "Sr25519": "Sr25519Signature"
    }
  },
  "PublicEncryptionKey": {
    "_enum": {
      "X55519": "[u8; 32]"
    }
  },
  "DidError": {
    "_enum": {
      "StorageError": "StorageError",
      "SignatureError": "SignatureError",
      "OperationError": "OperationError",
      "UrlError": "UrlError"
    }
  },
  "StorageError": {
    "_enum": {
      "DidAlreadyPresent": "null",
      "DidNotPresent": "null",
      "DidKeyNotPresent": "DidVerificationKeyType",
      "VerificationKeysNotPresent": "Vec<PublicVerificationKey>"
    }
  },
  "SignatureError": {
    "_enum": [
      "InvalidSignatureFormat",
      "InvalidSignature"
    ]
  },
  "OperationError": {
    "_enum": [
      "InvalidNonce"
    ]
  },
  "UrlError": {
    "_enum": [
      "InvalidUrlEncoding",
      "InvalidUrlScheme"
    ]
  },
  "Url": {
    "_enum": {
      "Http": "HttpUrl",
      "Ftp": "FtpUrl",
      "Ipfs": "IpfsUrl"
    }
  },
  "HttpUrl": {
    "payload": "Text"
  },
  "FtpUrl": {
    "payload": "Text"
  },
  "IpfsUrl": {
    "payload": "Text"
  },
  "DidCreationOperation": {
    "did": "DidIdentifier",
    "new_auth_key": "PublicVerificationKey",
    "new_key_agreement_key": "PublicEncryptionKey",
    "new_attestation_key": "Option<PublicVerificationKey>",
    "new_delegation_key": "Option<PublicVerificationKey>",
    "new_endpoint_url": "Option<Url>"
  },
  "DidUpdateOperation": {
    "did": "DidIdentifier",
    "new_auth_key": "Option<PublicVerificationKey>",
    "new_key_agreement_key": "Option<PublicEncryptionKey>",
    "new_attestation_key": "Option<PublicVerificationKey>",
    "new_delegation_key": "Option<PublicVerificationKey>",
    "verification_keys_to_remove": "Option<BTreeSet<PublicVerificationKey>>",
    "new_endpoint_url": "Option<Url>",
    "tx_counter": "u64"
  },
  "DidDeletionOperation": {
    "did": "DidIdentifier",
    "tx_counter": "u64"
  },
  "DidCallOperation": {
    "did": "DidIdentifier",
    "txCounter": "u64",
    "call": "Call"
  },
  "DidDetails": {
    "auth_key": "PublicVerificationKey",
    "key_agreement_key": "PublicEncryptionKey",
    "delegation_key": "Option<PublicVerificationKey>",
    "attestation_key": "Option<PublicVerificationKey>",
    "verification_keys": "BTreeSet<PublicVerificationKey>",
    "endpoint_url": "Option<Url>",
    "last_tx_counter": "u64"
  },
  "LockedBalance": {
    "block": "BlockNumber",
    "amount": "Balance"
  }
}
</details>

## Checklist:

- [ ] I have verified that the code works
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [ ] I have documented the changes (where applicable)
