### PR TITLE
feat: add benchmarking to parachain runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3343,6 +3343,8 @@ dependencies = [
  "cumulus-primitives-core",
  "derive_more 0.15.0",
  "exit-future 0.1.4",
+ "frame-benchmarking",
+ "frame-benchmarking-cli",
  "futures 0.3.14",
  "hex-literal 0.2.1",
  "jsonrpc-core",
@@ -10209,13 +10211,13 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a3d51ad6abbc408b03ea962062bfcc959b438a318d7d4bedd181e1effd0610"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#2be8fcc4236d32786c62f6f27a98e7fe7e550807"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "build-helper",
  "cargo_metadata",
+ "sp-maybe-compressed-blob",
  "tempfile",
  "toml",
  "walkdir",
@@ -10225,13 +10227,13 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-v1#2be8fcc4236d32786c62f6f27a98e7fe7e550807"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a3d51ad6abbc408b03ea962062bfcc959b438a318d7d4bedd181e1effd0610"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
  "build-helper",
  "cargo_metadata",
- "sp-maybe-compressed-blob",
  "tempfile",
  "toml",
  "walkdir",

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -76,6 +76,10 @@ polkadot-primitives = {git = "https://github.com/paritytech/polkadot", branch = 
 polkadot-service = {git = "https://github.com/paritytech/polkadot", branch = "rococo-v1"}
 polkadot-test-service = {git = "https://github.com/paritytech/polkadot", branch = "rococo-v1"}
 
+# Benchmarking
+frame-benchmarking = {git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1"}
+frame-benchmarking-cli = {git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1"}
+
 [build-dependencies]
 substrate-build-script-utils = {git = "https://github.com/paritytech/substrate", branch = "rococo-v1"}
 

--- a/nodes/parachain/src/cli.rs
+++ b/nodes/parachain/src/cli.rs
@@ -51,6 +51,10 @@ pub enum Subcommand {
 
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
+
+	/// The custom benchmark subcommmand benchmarking runtime pallets.
+	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
+	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 }
 
 /// Command for exporting the genesis state of the parachain

--- a/nodes/parachain/src/command.rs
+++ b/nodes/parachain/src/command.rs
@@ -19,6 +19,7 @@
 use crate::{
 	chain_spec,
 	cli::{Cli, RelayChainCli, Subcommand},
+	service::Executor,
 };
 use codec::Encode;
 use cumulus_client_service::genesis::generate_genesis_block;
@@ -216,6 +217,17 @@ pub fn run() -> Result<()> {
 				} = crate::service::new_partial(&config)?;
 				Ok((cmd.run(client, backend), task_manager))
 			})
+		}
+		Some(Subcommand::Benchmark(cmd)) => {
+			if cfg!(feature = "runtime-benchmarks") {
+				let runner = cli.create_runner(cmd)?;
+
+				runner.sync_run(|config| cmd.run::<Block, Executor>(config))
+			} else {
+				Err("Benchmarking wasn't enabled when building the node. \
+				You can enable it with `--features runtime-benchmarks`."
+					.into())
+			}
 		}
 		Some(Subcommand::ExportGenesisState(params)) => {
 			let mut builder = sc_cli::LoggerBuilder::new("");

--- a/nodes/parachain/src/service.rs
+++ b/nodes/parachain/src/service.rs
@@ -38,6 +38,7 @@ native_executor_instance!(
 	pub Executor,
 	kilt_parachain_runtime::api::dispatch,
 	kilt_parachain_runtime::native_version,
+	frame_benchmarking::benchmarking::HostFunctions,
 );
 
 type PartialComponentsType = sc_service::PartialComponents<


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1282
* adds benchmarking command to parachain runtime

## How to test:
```bash
cd nodes/parachain
cargo run --release --features runtime-benchmarks -- benchmark --execution=wasm --wasm-execution=Compiled --heap-pages=4096 --extrinsic=\* --pallet=kilt_launch --steps=10 --repeat=4 --output ../../pallets/kilt-launch/src/default_weights.rs --template ../../.maintain/weight-template.hbs
```

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
- [x] This PR does not introduce new custom types
(https://github.com/KILTprotocol/type-definitions/pulls)
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
