### PR TITLE
feat: move version to primitives

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -78,22 +78,13 @@ pub type Hash = sp_core::H256;
 /// Digest item type.
 pub type DigestItem = generic::DigestItem<Hash>;
 
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum CurrencyId {
-	Dot = 0_isize,
-	Ksm,
-	Kilt,
-}
-
-impl TryFrom<Vec<u8>> for CurrencyId {
-	type Error = ();
-	fn try_from(v: Vec<u8>) -> Result<CurrencyId, ()> {
-		match v.as_slice() {
-			b"KILT" => Ok(CurrencyId::Kilt),
-			b"DOT" => Ok(CurrencyId::Dot),
-			b"KSM" => Ok(CurrencyId::Ksm),
-			_ => Err(()),
-		}
-	}
-}
+/// This runtime version.
+pub const VERSION: RuntimeVersion = RuntimeVersion {
+	spec_name: create_runtime_str!("mashnet-node"),
+	impl_name: create_runtime_str!("mashnet-node"),
+	authoring_version: 4,
+	spec_version: 8,
+	impl_version: 0,
+	apis: RUNTIME_API_VERSIONS,
+	transaction_version: 2,
+};

--- a/runtimes/parachain/src/lib.rs
+++ b/runtimes/parachain/src/lib.rs
@@ -34,7 +34,7 @@ use frame_system::{
 };
 use kilt_primitives::{
 	constants::{DAYS, DOLLARS, HOURS, MILLICENTS, MIN_VESTED_TRANSFER_AMOUNT, SLOT_DURATION},
-	AccountId, Balance, BlockNumber, Hash, Index, Signature,
+	AccountId, Balance, BlockNumber, Hash, Index, Signature, VERSION,
 };
 use sp_api::impl_runtime_apis;
 use sp_core::{
@@ -81,17 +81,6 @@ pub type SessionHandlers = ();
 impl_opaque_keys! {
 	pub struct SessionKeys {}
 }
-
-/// This runtime version.
-pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("mashnet-node"),
-	impl_name: create_runtime_str!("mashnet-node"),
-	authoring_version: 1,
-	spec_version: 3,
-	impl_version: 0,
-	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
-};
 
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
 	items as Balance * 20 * DOLLARS + (bytes as Balance) * 100 * MILLICENTS

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -30,7 +30,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 use grandpa::{fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use kilt_primitives::{
 	constants::{DOLLARS, MIN_VESTED_TRANSFER_AMOUNT, SLOT_DURATION},
-	AccountId, Balance, BlockNumber, Hash, Index, Signature,
+	AccountId, Balance, BlockNumber, Hash, Index, Signature, VERSION,
 };
 use pallet_transaction_payment::{CurrencyAdapter, FeeDetails};
 use sp_api::impl_runtime_apis;
@@ -99,17 +99,6 @@ pub mod opaque {
 		}
 	}
 }
-
-/// This runtime version.
-pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("mashnet-node"),
-	impl_name: create_runtime_str!("mashnet-node"),
-	authoring_version: 4,
-	spec_version: 8,
-	impl_version: 0,
-	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 2,
-};
 
 /// The version information used to identify this runtime when compiled
 /// natively.


### PR DESCRIPTION
* Add companion PR for types to template
* use the same version in the parachain and standalone
  * this way we can use the same types and have the same version bounds
  * the two versions are very close (and should probably be the same anyways)
* also removes old currency types

### custom types

types are unaffected.

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
