### PR TITLE
fix: fix types in delegation pallet and event in did pallet

### DIFF
--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -313,7 +313,7 @@ pub mod pallet {
 		#[pallet::weight(0)]
 		pub fn revoke_root(
 			origin: OriginFor<T>,
-			root_id: T::DelegationNodeId,
+			root_id: DelegationNodeIdOf<T>,
 			max_children: u32,
 		) -> DispatchResultWithPostInfo {
 			let invoker = <T as Config>::EnsureOrigin::ensure_origin(origin)?;
@@ -516,7 +516,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	// Add a child node into the delegation hierarchy
-	fn add_child(child: T::DelegationNodeId, parent: T::DelegationNodeId) {
+	fn add_child(child: DelegationNodeIdOf<T>, parent: DelegationNodeIdOf<T>) {
 		// Get the children vector or initialize an empty one if none
 		let mut children = <Children<T>>::get(parent).unwrap_or_default();
 		children.push(child);


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1299
Fix some minor errors in the types used in the delegation pallet and the dispatch call event payload in the did pallet.

## How to test:

Run `cargo test --all --all-features` to test the chain code. Interact with the node from Polkadot-JS apps using the provided types.

### custom types

The PR https://github.com/KILTprotocol/type-definitions/pull/1 has already been tested with the current version of the node and it seems to be working fine. Ask @rflechtner for instructions on how to run those test cases.

Please use the following types to test the code with the Polkadot Apps:

<details>
  <summary>JS-Types</summary>
  
  ```json
{
	"Address": "MultiAddress",
	"AmountOf": "i128",
	"Balance": "u128",
    "BlockNumber": "u64",
    "Index": "u64",
    "LookupSource": "MultiAddress",

    "CtypeCreatorOf": "DidIdentifierOf",
    "CtypeHashOf": "Hash",

	"ClaimHashOf": "Hash",
	"AttesterOf": "DidIdentifierOf",
	"AttestationDetails": {
		"ctype_hash": "CtypeHashOf",
		"attester": "AttesterOf",
		"delegation_id": "Option<DelegationNodeIdOf>",
		"revoked": "bool"
	},

	"Permissions": "u32",
	"DelegationNodeIdOf": "Hash",
	"DelegatorIdOf": "DidIdentifierOf",
	"DelegationSignature": "DidSignature",
	"DelegationRoot": {
		"ctype_hash": "CtypeHashOf",
		"owner": "DelegatorIdOf",
		"revoked": "bool"
	},
	"DelegationNode": {
		"root_id": "DelegationNodeIdOf",
		"parent": "Option<DelegationNodeIdOf>",
		"owner": "DelegatorIdOf",
		"permissions": "Permissions",
		"revoked": "bool"
	},

	"KeyIdOf": "Hash",
	"DidIdentifierOf": "AccountId",
	"AccountIdentifierOf": "AccountId",
	"BlockNumberOf": "BlockNumber",
	"DidCallableOf": "Call",
	"DidVerificationKey": {
	  "_enum": {
		"Ed25519": "[u8; 32]",
		"Sr25519": "[u8; 32]"
	  }
	},
	"DidEncryptionKey": {
	  "_enum": {
		"X25519": "[u8; 32]"
	  }
	},		
	"DidPublicKey": {
		"_enum": {
			"PublicVerificationKey": "DidVerificationKey",
			"PublicEncryptionKey": "DidEncryptionKey"
		}
	},
	"DidVerificationKeyRelationship": {
	  "_enum": [
		"Authentication",
		"CapabilityDelegation",
		"CapabilityInvocation",
		"AssertionMethod"
	  ]
	},
	"DidSignature": {
	  "_enum": {
		"Ed25519": "Ed25519Signature",
		"Sr25519": "Sr25519Signature"
	  }
	},
	"DidError": {
	  "_enum": {
		"StorageError": "StorageError",
		"SignatureError": "SignatureError",
		"UrlError": "UrlError",
		"InternalError": "Null"
	  }
	},
	"StorageError": {
	  "_enum": {
		"DidAlreadyPresent": "Null",
		"DidNotPresent": "Null",
		"DidKeyNotPresent": "DidVerificationKeyRelationship",
		"VerificationKeyNotPresent": "Null",
		"CurrentlyActiveKey": "Null",
		"MaxTxCounterValue": "Null"
	  }
	},
	"SignatureError": {
	  "_enum": [
		"InvalidSignatureFormat",
		"InvalidSignature",
		"InvalidNonce"
	  ]
	},
	"KeyError": {
		"_enum": [
			"InvalidVerificationKeyFormat",
			"InvalidEncryptionKeyFormat"
		]
	},
	"UrlError": {
		"_enum": [
			"InvalidUrlEncoding",
			"InvalidUrlScheme"
		]
	},
	"DidPublicKeyDetails": {
		"key": "DidPublicKey",
		"block_number": "BlockNumberOf"
	},
	"DidDetails": {
	  "authentication_key": "KeyIdOf",
	  "key_agreement_keys": "BTreeSet<KeyIdOf>",
	  "delegation_key": "Option<KeyIdOf>",
	  "attestation_key": "Option<KeyIdOf>",
	  "public_keys": "BTreeMap<KeyIdOf, DidPublicKeyDetails>",
	  "endpoint_url": "Option<Url>",
	  "last_tx_counter": "u64"
	},
	"DidCreationOperation": {
	  "did": "DidIdentifierOf",
	  "new_authentication_key": "DidVerificationKey",
	  "new_key_agreement_keys": "BTreeSet<DidEncryptionKey>",
	  "new_attestation_key": "Option<DidVerificationKey>",
	  "new_delegation_key": "Option<DidVerificationKey>",
	  "new_endpoint_url": "Option<Url>"
	},
	"DidUpdateOperation": {
	  "did": "DidIdentifierOf",
	  "new_authentication_key": "Option<DidVerificationKey>",
	  "new_key_agreement_keys": "BTreeSet<DidEncryptionKey>",
	  "attestation_key_update": "DidVerificationKeyUpdateAction",
	  "delegation_key_update": "DidVerificationKeyUpdateAction",
	  "public_keys_to_remove": "BTreeSet<KeyIdOf>",
	  "new_endpoint_url": "Option<Url>",
	  "tx_counter": "u64"
	},
	"DidVerificationKeyUpdateAction": {
		"_enum": {
			"Ignore": "Null",
			"Change": "DidVerificationKey",
			"Delete": "Null"
		}
	},
	"DidDeletionOperation": {
	  "did": "DidIdentifierOf",
	  "tx_counter": "u64"
	},
	"DidAuthorizedCallOperation": {
		"did": "DidIdentifierOf",
		"tx_counter": "u64",
		"call": "DidCallableOf"
	},
	"HttpUrl": {
		"payload": "Text"
	},
	"FtpUrl": {
		"payload": "Text"
	},
	"IpfsUrl": {
		"payload": "Text"
	},
	"Url": {
		"_enum": {
			"Http": "HttpUrl",
			"Ftp": "FtpUrl",
			"Ipfs": "IpfsUrl"
		}
	},

	"LockedBalance": {
		"block": "BlockNumber",
		"amount": "Balance"
	}
}
  ```
</details>

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
- [ ] This PR does not introduce new custom types
  - [x] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls/1)
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
