### PR TITLE
fix: couldn't revoke empty delegation root

### DIFF
--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -326,7 +326,8 @@ pub mod pallet {
 				// Recursively revoke all children
 				let (_, post_weight) = Self::revoke_children(&root_id, &invoker, max_children)?;
 
-				// If we didn't return an ExceededRevocationBounds error, we can revoke the root to.
+				// If we didn't return an ExceededRevocationBounds error, we can revoke the root
+				// to.
 				root.revoked = true;
 				<Roots<T>>::insert(&root_id, root);
 

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -327,7 +327,7 @@ pub mod pallet {
 				let (_, post_weight) = Self::revoke_children(&root_id, &invoker, max_children)?;
 
 				// If we didn't return an ExceededRevocationBounds error, we can revoke the root
-				// to.
+				// too.
 				root.revoked = true;
 				<Roots<T>>::insert(&root_id, root);
 
@@ -485,7 +485,7 @@ impl<T: Config> Pallet<T> {
 		Ok((revocations, consumed_weight))
 	}
 
-	/// revoke_children revokes all children of a delegation.
+	/// Revokes all children of a delegation.
 	/// Returns the number of revoked delegations and the consumed weight.
 	fn revoke_children(
 		delegation: &DelegationNodeIdOf<T>,

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -324,13 +324,12 @@ pub mod pallet {
 
 			let consumed_weight: Weight = if !root.revoked {
 				// Recursively revoke all children
-				let (remaining_revocations, post_weight) = Self::revoke_children(&root_id, &invoker, max_children)?;
+				let (_, post_weight) = Self::revoke_children(&root_id, &invoker, max_children)?;
 
-				// If gas left, store revoked root node
-				if remaining_revocations > 0 {
-					root.revoked = true;
-					<Roots<T>>::insert(&root_id, root);
-				}
+				// If we didn't return an ExceededRevocationBounds error, we can revoke the root to.
+				root.revoked = true;
+				<Roots<T>>::insert(&root_id, root);
+
 				post_weight.saturating_add(T::DbWeight::get().writes(1))
 			} else {
 				0
@@ -485,7 +484,8 @@ impl<T: Config> Pallet<T> {
 		Ok((revocations, consumed_weight))
 	}
 
-	// Revoke all children of a delegation
+	/// revoke_children revokes all children of a delegation.
+	/// Returns the number of revoked delegations and the consumed weight.
 	fn revoke_children(
 		delegation: &DelegationNodeIdOf<T>,
 		sender: &DelegatorIdOf<T>,


### PR DESCRIPTION
## No Ticket

Revoking a delegation root without any children didn't work since we misused the returned value of `revoke_children`. `revoke_children` doesn't return the remaining revocations, but the number of revoked children.

### custom types

No Change

## Checklist:

- [x] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
