### PR TITLE
fix: don't transfer expired locks

### DIFF
--- a/pallets/kilt-launch/src/lib.rs
+++ b/pallets/kilt-launch/src/lib.rs
@@ -721,6 +721,23 @@ pub mod pallet {
 			// Otherwise, this will always be the source's locked amount
 			let max_add_amount = source_amount.min(max_amount.unwrap_or(source_amount));
 
+			// We don't need to transfer any locks if the lock already expired. So we bail early
+			if unlock_block <= frame_system::Pallet::<T>::block_number() {
+				// But we still need to reduce the old lock or remove it, if it's consumed completly.
+				if max_add_amount == source_amount {
+					<BalanceLocks<T>>::remove(&source);
+				} else {
+					<BalanceLocks<T>>::insert(
+						&source,
+						LockedBalance::<T> {
+							block: unlock_block,
+							amount: source_amount.saturating_sub(max_add_amount),
+						},
+					)
+				}
+				return Ok(T::DbWeight::get().reads(1));
+			}
+
 			// Check for an already existing KILT balance lock on the target
 			// account which would be the case if the claimer requests migration from
 			// multiple source accounts to the same target

--- a/pallets/kilt-launch/src/lib.rs
+++ b/pallets/kilt-launch/src/lib.rs
@@ -725,7 +725,7 @@ pub mod pallet {
 			// early
 			if unlock_block <= frame_system::Pallet::<T>::block_number() {
 				// But we still need to reduce the old lock or remove it, if it's consumed
-				// completly.
+				// completely.
 				if max_add_amount == source_amount {
 					<BalanceLocks<T>>::remove(&source);
 				} else {

--- a/pallets/kilt-launch/src/lib.rs
+++ b/pallets/kilt-launch/src/lib.rs
@@ -721,9 +721,11 @@ pub mod pallet {
 			// Otherwise, this will always be the source's locked amount
 			let max_add_amount = source_amount.min(max_amount.unwrap_or(source_amount));
 
-			// We don't need to transfer any locks if the lock already expired. So we bail early
+			// We don't need to transfer any locks if the lock already expired. So we bail
+			// early
 			if unlock_block <= frame_system::Pallet::<T>::block_number() {
-				// But we still need to reduce the old lock or remove it, if it's consumed completly.
+				// But we still need to reduce the old lock or remove it, if it's consumed
+				// completly.
 				if max_add_amount == source_amount {
 					<BalanceLocks<T>>::remove(&source);
 				} else {

--- a/pallets/kilt-launch/src/mock.rs
+++ b/pallets/kilt-launch/src/mock.rs
@@ -178,13 +178,16 @@ pub fn ensure_single_migration_works(
 		num_of_locks += 1;
 	}
 	if let Some((lock, _)) = locked_info.clone() {
-		assert_eq!(kilt_launch::BalanceLocks::<Test>::get(dest), Some(lock.clone()));
-		assert_eq!(
-			kilt_launch::UnlockingAt::<Test>::get(lock.block),
-			Some(vec![dest.to_owned()])
-		);
-		locked_balance = locked_balance.max(lock.amount);
-		num_of_locks += 1;
+		// only if the lock is not expired, it should show up here
+		if lock.block > now {
+			assert_eq!(kilt_launch::BalanceLocks::<Test>::get(dest), Some(lock.clone()));
+			assert_eq!(
+				kilt_launch::UnlockingAt::<Test>::get(lock.block),
+				Some(vec![dest.to_owned()])
+			);
+			locked_balance = locked_balance.max(lock.amount);
+			num_of_locks += 1;
+		}
 	}
 
 	// Check correct setting of locks for dest


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1341

>  When I migrate an account with a locked amount that unlocks at a block that is already in the past (block the amount is unlocked: 250 and the current block is 500), the amount is not unlocked.

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
