### PR TITLE
feat: set base transfer_keep_alive fee to 0.01 KILT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10380,6 +10380,7 @@ dependencies = [
  "polkadot-parachain",
  "rococo-runtime",
  "serde",
+ "smallvec 1.6.1",
  "sp-api",
  "sp-arithmetic",
  "sp-block-builder",

--- a/pallets/kilt-launch/Cargo.toml
+++ b/pallets/kilt-launch/Cargo.toml
@@ -25,6 +25,7 @@ sp-runtime = {git = "https://github.com/paritytech/substrate", default-features 
 kilt-primitives = {path = "../../primitives", default-features = false, optional = true}
 
 [dev-dependencies]
+kilt-primitives = {path = "../../primitives", default-features = false}
 sp-core = {git = "https://github.com/paritytech/substrate", default-features = false, version = "3.0.0", branch = "polkadot-v0.9.4"}
 sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, version = "3.0.0", branch = "polkadot-v0.9.4"}
 

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.2.0"
 codec = {package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"]}
 serde = {version = "1.0.101", optional = true, features = ["derive"]}
 static_assertions = "1.1.0"
+smallvec = "1.6.1"
 
 # RPC
 frame-system-rpc-runtime-api = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.4"}

--- a/runtimes/spiritnet/src/fee.rs
+++ b/runtimes/spiritnet/src/fee.rs
@@ -1,13 +1,9 @@
-use crate::weights::pallet_balances::WeightInfo;
-use frame_support::weights::{WeightToFeeCoefficients, WeightToFeePolynomial};
+use frame_support::weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial};
 use kilt_primitives::{constants::MILLI_KILT, Balance};
+use pallet_balances::WeightInfo;
 use smallvec::smallvec;
-/// Fee-related.
 pub use sp_runtime::Perbill;
 use sp_std::marker::PhantomData;
-
-/// The block saturation level. Fees will be updates based on this value.
-pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
 
 /// Handles converting a weight scalar to a fee value, based on the scale and
 /// granularity of the node's balance type.
@@ -21,8 +17,10 @@ pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
 ///   - Setting it to `0` will essentially disable the weight fee.
 ///   - Setting it to `1` will cause the literal `#[weight = x]` values to be
 ///     charged.
-pub struct WeightToFee<T>(PhantomData<T>);
-impl<T> WeightToFeePolynomial for WeightToFee<T> {
+pub struct WeightToFee<T>(PhantomData<T>)
+where
+	T: frame_system::Config;
+impl<T: frame_system::Config> WeightToFeePolynomial for WeightToFee<T> {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
 		// in Spiritnet, transfer weight is mapped to 0.001 KILT:
@@ -36,3 +34,5 @@ impl<T> WeightToFeePolynomial for WeightToFee<T> {
 		}]
 	}
 }
+
+// TODO: Add test

--- a/runtimes/spiritnet/src/fee.rs
+++ b/runtimes/spiritnet/src/fee.rs
@@ -1,5 +1,23 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2021 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
 use frame_support::weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial};
-use kilt_primitives::{constants::MILLI_KILT, Balance};
+use kilt_primitives::{constants::KILT, Balance};
 use pallet_balances::WeightInfo;
 use smallvec::smallvec;
 pub use sp_runtime::Perbill;
@@ -23,9 +41,11 @@ where
 impl<T: frame_system::Config> WeightToFeePolynomial for WeightToFee<T> {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		// in Spiritnet, transfer weight is mapped to 0.001 KILT:
-		let p = MILLI_KILT;
-		let q = 10 * Balance::from(crate::weights::pallet_balances::WeightInfo::<T>::transfer());
+		// in Spiritnet, transfer weight is mapped to 0.01 KILT:
+		let p = KILT / 100;
+		let q = Balance::from(crate::weights::pallet_balances::WeightInfo::<T>::transfer());
+
+		// f(w) = MILLI_KILT / WeightInfo::transfer() * w
 		smallvec![WeightToFeeCoefficient {
 			degree: 1,
 			negative: false,
@@ -36,3 +56,67 @@ impl<T: frame_system::Config> WeightToFeePolynomial for WeightToFee<T> {
 }
 
 // TODO: Add test
+
+#[cfg(test)]
+mod tests {
+	use super::WeightToFee;
+	use crate::{BlockHashCount, SS58Prefix};
+	use frame_support::weights::WeightToFeePolynomial;
+	use kilt_primitives::{constants::KILT, AccountId, Balance, BlockNumber, Hash, Index};
+	use pallet_balances::WeightInfo;
+	use sp_runtime::{
+		testing::Header,
+		traits::{BlakeTwo256, IdentityLookup},
+	};
+
+	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+	type Block = frame_system::mocking::MockBlock<Test>;
+
+	// Configure a mock runtime to test the pallet.
+	frame_support::construct_runtime!(
+		pub enum Test where
+			Block = Block,
+			NodeBlock = Block,
+			UncheckedExtrinsic = UncheckedExtrinsic,
+		{
+			System: frame_system::{Pallet, Call, Config, Storage, Event<T>}
+		}
+	);
+
+	impl frame_system::Config for Test {
+		type BaseCallFilter = ();
+		type BlockWeights = ();
+		type BlockLength = ();
+		type DbWeight = ();
+		type Origin = Origin;
+		type Call = Call;
+		type Index = Index;
+		type BlockNumber = BlockNumber;
+		type Hash = Hash;
+		type Hashing = BlakeTwo256;
+		type AccountId = AccountId;
+		type Lookup = IdentityLookup<Self::AccountId>;
+		type Header = Header;
+		type Event = Event;
+		type BlockHashCount = BlockHashCount;
+		type Version = ();
+		type PalletInfo = PalletInfo;
+		type AccountData = pallet_balances::AccountData<Balance>;
+		type OnNewAccount = ();
+		type OnKilledAccount = ();
+		type SystemWeightInfo = ();
+		type SS58Prefix = SS58Prefix;
+		type OnSetCode = ();
+	}
+
+	#[test]
+	fn transaction_fee_is_correct() {
+		assert_eq!(
+			WeightToFee::<Test>::calc(&crate::weights::pallet_balances::WeightInfo::<Test>::transfer()),
+			KILT / 100
+		);
+	}
+
+	// TODO: Add test for full block weight once attestation weights have been
+	// calculated
+}

--- a/runtimes/spiritnet/src/fee.rs
+++ b/runtimes/spiritnet/src/fee.rs
@@ -1,0 +1,38 @@
+use crate::weights::pallet_balances::WeightInfo;
+use frame_support::weights::{WeightToFeeCoefficients, WeightToFeePolynomial};
+use kilt_primitives::{constants::MILLI_KILT, Balance};
+use smallvec::smallvec;
+/// Fee-related.
+pub use sp_runtime::Perbill;
+use sp_std::marker::PhantomData;
+
+/// The block saturation level. Fees will be updates based on this value.
+pub const TARGET_BLOCK_FULLNESS: Perbill = Perbill::from_percent(25);
+
+/// Handles converting a weight scalar to a fee value, based on the scale and
+/// granularity of the node's balance type.
+///
+/// This should typically create a mapping between the following ranges:
+///   - [0, MAXIMUM_BLOCK_WEIGHT]
+///   - [Balance::min, Balance::max]
+///
+/// Yet, it can be used for any other sort of change to weight-fee. Some
+/// examples being:
+///   - Setting it to `0` will essentially disable the weight fee.
+///   - Setting it to `1` will cause the literal `#[weight = x]` values to be
+///     charged.
+pub struct WeightToFee<T>(PhantomData<T>);
+impl<T> WeightToFeePolynomial for WeightToFee<T> {
+	type Balance = Balance;
+	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		// in Spiritnet, transfer weight is mapped to 0.001 KILT:
+		let p = MILLI_KILT;
+		let q = 10 * Balance::from(crate::weights::pallet_balances::WeightInfo::<T>::transfer());
+		smallvec![WeightToFeeCoefficient {
+			degree: 1,
+			negative: false,
+			coeff_frac: Perbill::from_rational(p % q, q),
+			coeff_integer: p / q,
+		}]
+	}
+}

--- a/runtimes/spiritnet/src/fee.rs
+++ b/runtimes/spiritnet/src/fee.rs
@@ -55,64 +55,19 @@ impl<T: frame_system::Config> WeightToFeePolynomial for WeightToFee<T> {
 	}
 }
 
-// TODO: Add test
-
 #[cfg(test)]
 mod tests {
 	use super::WeightToFee;
-	use crate::{BlockHashCount, SS58Prefix};
 	use frame_support::weights::WeightToFeePolynomial;
-	use kilt_primitives::{constants::KILT, AccountId, Balance, BlockNumber, Hash, Index};
+	use kilt_primitives::constants::KILT;
 	use pallet_balances::WeightInfo;
-	use sp_runtime::{
-		testing::Header,
-		traits::{BlakeTwo256, IdentityLookup},
-	};
-
-	type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
-	type Block = frame_system::mocking::MockBlock<Test>;
-
-	// Configure a mock runtime to test the pallet.
-	frame_support::construct_runtime!(
-		pub enum Test where
-			Block = Block,
-			NodeBlock = Block,
-			UncheckedExtrinsic = UncheckedExtrinsic,
-		{
-			System: frame_system::{Pallet, Call, Config, Storage, Event<T>}
-		}
-	);
-
-	impl frame_system::Config for Test {
-		type BaseCallFilter = ();
-		type BlockWeights = ();
-		type BlockLength = ();
-		type DbWeight = ();
-		type Origin = Origin;
-		type Call = Call;
-		type Index = Index;
-		type BlockNumber = BlockNumber;
-		type Hash = Hash;
-		type Hashing = BlakeTwo256;
-		type AccountId = AccountId;
-		type Lookup = IdentityLookup<Self::AccountId>;
-		type Header = Header;
-		type Event = Event;
-		type BlockHashCount = BlockHashCount;
-		type Version = ();
-		type PalletInfo = PalletInfo;
-		type AccountData = pallet_balances::AccountData<Balance>;
-		type OnNewAccount = ();
-		type OnKilledAccount = ();
-		type SystemWeightInfo = ();
-		type SS58Prefix = SS58Prefix;
-		type OnSetCode = ();
-	}
 
 	#[test]
-	fn transaction_fee_is_correct() {
+	fn transaction_fee_is_correct_runtime() {
 		assert_eq!(
-			WeightToFee::<Test>::calc(&crate::weights::pallet_balances::WeightInfo::<Test>::transfer()),
+			WeightToFee::<crate::Runtime>::calc(
+				&crate::weights::pallet_balances::WeightInfo::<crate::Runtime>::transfer()
+			),
 			KILT / 100
 		);
 	}

--- a/runtimes/spiritnet/src/fee.rs
+++ b/runtimes/spiritnet/src/fee.rs
@@ -16,9 +16,13 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use frame_support::weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial};
+use frame_support::{
+	traits::Get,
+	weights::{WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial},
+};
 use kilt_primitives::{constants::KILT, Balance};
 use pallet_balances::WeightInfo;
+use pallet_transaction_payment::OnChargeTransaction;
 use smallvec::smallvec;
 pub use sp_runtime::Perbill;
 use sp_std::marker::PhantomData;
@@ -37,15 +41,25 @@ use sp_std::marker::PhantomData;
 ///     charged.
 pub struct WeightToFee<T>(PhantomData<T>)
 where
-	T: frame_system::Config;
-impl<T: frame_system::Config> WeightToFeePolynomial for WeightToFee<T> {
+	T: frame_system::Config + pallet_transaction_payment::Config,
+	Balance: From<<<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance>;
+impl<T: frame_system::Config + pallet_transaction_payment::Config> WeightToFeePolynomial for WeightToFee<T>
+where
+	Balance: From<<<T as pallet_transaction_payment::Config>::OnChargeTransaction as OnChargeTransaction<T>>::Balance>,
+{
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
 		// in Spiritnet, transfer weight is mapped to 0.01 KILT:
-		let p = KILT / 100;
-		let q = Balance::from(crate::weights::pallet_balances::WeightInfo::<T>::transfer());
+		let wanted_fee: Balance = KILT / 100;
+		let per_byte: Balance = Balance::from(<T as pallet_transaction_payment::Config>::TransactionByteFee::get());
+		let tx_byte_fee = Perbill::from_parts(1) * per_byte;
 
-		// f(w) = MILLI_KILT / WeightInfo::transfer() * w
+		let max: Balance = wanted_fee.max(tx_byte_fee);
+		let min: Balance = wanted_fee.min(tx_byte_fee);
+		let p: Balance = max - min;
+		let q: Balance = crate::weights::pallet_balances::WeightInfo::<T>::transfer_keep_alive().into();
+
+		// f(w) = MILLI_KILT / WeightInfo::transfer_keep_alive() * w
 		smallvec![WeightToFeeCoefficient {
 			degree: 1,
 			negative: false,
@@ -57,19 +71,34 @@ impl<T: frame_system::Config> WeightToFeePolynomial for WeightToFee<T> {
 
 #[cfg(test)]
 mod tests {
-	use super::WeightToFee;
-	use frame_support::weights::WeightToFeePolynomial;
-	use kilt_primitives::constants::KILT;
-	use pallet_balances::WeightInfo;
+	use super::*;
+	use crate::{AccountId, Call, Runtime, TransactionPayment};
+	use codec::Encode;
+	use sp_runtime::traits::Zero;
 
 	#[test]
-	fn transaction_fee_is_correct_runtime() {
-		assert_eq!(
-			WeightToFee::<crate::Runtime>::calc(
-				&crate::weights::pallet_balances::WeightInfo::<crate::Runtime>::transfer()
-			),
-			KILT / 100
-		);
+	fn transaction_fee_is_correct() {
+		let storage = frame_system::GenesisConfig::default()
+			.build_storage::<Runtime>()
+			.unwrap();
+		let mut ext = sp_io::TestExternalities::new(storage);
+		ext.execute_with(|| {
+			let tx = Call::Balances(pallet_balances::Call::transfer_keep_alive(
+				AccountId::default().into(),
+				Balance::zero(),
+			));
+
+			let info = TransactionPayment::query_fee_details(tx.clone(), tx.encode().len() as u32);
+			let incl_fee = info.inclusion_fee.unwrap();
+			assert_eq!(
+				incl_fee.base_fee + incl_fee.len_fee + incl_fee.adjusted_weight_fee,
+				KILT / 100,
+				"base fee: {:?} byte fee: {:?} adjusted fee {:?}",
+				incl_fee.base_fee,
+				incl_fee.len_fee,
+				incl_fee.adjusted_weight_fee
+			);
+		})
 	}
 
 	// TODO: Add test for full block weight once attestation weights have been

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -218,7 +218,7 @@ impl pallet_timestamp::Config for Runtime {
 
 parameter_types! {
 	pub const ExistentialDeposit: u128 = 100 * MILLI_KILT;
-	pub const TransactionByteFee: u128 = 1;
+	pub const TransactionByteFee: u128 = MILLI_KILT;
 	pub const MaxLocks: u32 = 50;
 }
 

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -194,7 +194,7 @@ impl frame_system::Config for Runtime {
 	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
-	type DbWeight = ();
+	type DbWeight = RocksDbWeight;
 	type BaseCallFilter = BaseFilter;
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	type BlockWeights = RuntimeBlockWeights;

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -65,6 +65,7 @@ pub use sp_runtime::{Perbill, Permill};
 
 pub use parachain_staking::{InflationInfo, RewardRate, StakingInfo};
 
+mod fee;
 mod weights;
 
 #[cfg(any(feature = "std", test))]
@@ -244,7 +245,7 @@ impl pallet_balances::Config for Runtime {
 impl pallet_transaction_payment::Config for Runtime {
 	type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, ()>;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = IdentityFee<Balance>;
+	type WeightToFee = fee::WeightToFee<Runtime>;
 	type FeeMultiplierUpdate = ();
 }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1301
* Adds `RocksDbWeight` to `frame_system::Config::DbWeight`
* Increases `TransactionByteFee` from 1 to 0.01 KILT.
* Attempts to set the fee of `transfer_keep_alive` to 0.01 KILT assuming the block is empty-ish

## How to test:
1. Run node locally
```
cargo run --release -p kilt-parachain -- --runtime spiritnet --chain=spiritnet-dev --collator --tmp --ws-port=9944 --port 30444 --alice --ws-external --rpc-external --rpc-cors all --rpc-methods=unsafe --unsafe-rpc-external -- --chain=dev-specs/kilt-parachain/peregrine-relay.json
```
2. Check transfer fee in Polkadot Apps

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
