### PR TITLE
feat: set existential deposit to 0.01 KILT

### DIFF
--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -224,7 +224,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = 100 * MILLI_KILT;
+	pub const ExistentialDeposit: u128 = 10 * MILLI_KILT;
 	pub const TransactionByteFee: u128 = MICRO_KILT;
 	pub const MaxLocks: u32 = 50;
 	pub const MaxReserves: u32 = 50;

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -220,7 +220,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = 100 * MILLI_KILT;
+	pub const ExistentialDeposit: u128 = 10 * MILLI_KILT;
 	pub const TransactionByteFee: u128 = MICRO_KILT;
 	pub const MaxLocks: u32 = 50;
 	pub const MaxReserves: u32 = 50;

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -239,7 +239,7 @@ impl pallet_indices::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: Balance = 100 * MILLI_KILT;
+	pub const ExistentialDeposit: Balance = 10 * MILLI_KILT;
 	pub const MaxLocks: u32 = 50;
 	pub const MaxReserves: u32 = 50;
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1441
Sets the existential deposit to 0.01 KILT

## How to test:
constants -> balance -> existentialDeposit

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
