### PR TITLE
fix: enable chained staking migrations

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -512,7 +512,7 @@ pub mod pallet {
 				weight = weight.saturating_add(migrations::v4::migrate::<T>());
 			}
 			log::debug!("[END] parachain-staking::on_runtime_upgrade");
-			weight
+			weight.saturating_add(T::DbWeight::get().reads(3))
 		}
 
 		#[cfg(feature = "try-runtime")]

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -486,7 +486,12 @@ pub mod pallet {
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<(), &'static str> {
 			log::debug!("[BEGIN] parachain-staking::pre_upgrade");
-			let pre_migration_checks = migrations::v4::pre_migrate::<T>();
+			let pre_migration_checks = match <StorageVersion<T>>::get() {
+				Releases::V1_0_0 => migrations::v2::pre_migrate::<T>(),
+				Releases::V2_0_0 => migrations::v3::pre_migrate::<T>(),
+				Releases::V3_0_0 => migrations::v4::pre_migrate::<T>(),
+				Releases::V4 => Err("Already migrated"),
+			};
 			log::debug!("[END] parachain-staking::pre_upgrade");
 			pre_migration_checks
 		}
@@ -495,10 +500,19 @@ pub mod pallet {
 		fn on_runtime_upgrade() -> Weight {
 			#[cfg(feature = "try-runtime")]
 			log::debug!("[BEGIN] parachain-staking::on_runtime_upgrade");
-			let migration_consumed_weight = migrations::v4::migrate::<T>();
-			#[cfg(feature = "try-runtime")]
+			let mut weight = Weight::zero();
+
+			if <StorageVersion<T>>::get() == Releases::V1_0_0 {
+				weight = weight.saturating_add(migrations::v2::migrate::<T>());
+			}
+			if <StorageVersion<T>>::get() == Releases::V2_0_0 {
+				weight = weight.saturating_add(migrations::v3::migrate::<T>());
+			}
+			if <StorageVersion<T>>::get() == Releases::V3_0_0 {
+				weight = weight.saturating_add(migrations::v4::migrate::<T>());
+			}
 			log::debug!("[END] parachain-staking::on_runtime_upgrade");
-			migration_consumed_weight
+			weight
 		}
 
 		#[cfg(feature = "try-runtime")]


### PR DESCRIPTION
* Replaces staking migrations based on the latest version with chained migrations from the earliest to the latest version

## How to test:

### WILT

#### Quick and dirty
```
RUST_LOG=info cargo run -p kilt-parachain --features try-runtime -- try-runtime --chain=spiritnet-dev --execution wasm --wasm-execution compiled on-runtime-upgrade live wss://westend.kilt.io
```

#### With WILT spec
```
cargo run --release -p kilt-parachain --features try-runtime build-spec --chain wilt-new --disable-default-bootnode --raw > wilt-try-runtime.json
RUST_LOG=info cargo run -p kilt-parachain --features try-runtime -- try-runtime --chain=wilt-try-runtime.json --execution wasm --wasm-execution compiled on-runtime-upgrade live wss://westend.kilt.io
```

### Peregrine Staging
```
RUST_LOG=info cargo run -p kilt-parachain --features try-runtime -- try-runtime --execution wasm --wasm-execution compiled on-runtime-upgrade live wss://kilt-peregrine-stg.kilt.io
```

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
- [x] This PR does not introduce new custom types
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
