### PR TITLE
feat: unlimited candidates

### DIFF
--- a/pallets/parachain-staking/src/benchmarking.rs
+++ b/pallets/parachain-staking/src/benchmarking.rs
@@ -183,7 +183,7 @@ benchmarks! {
 	}
 
 	set_max_selected_candidates {
-		let n in (T::MinTopCandidates::get()) .. T::MaxTopCandidates::get();
+		let n in (T::MinCollators::get()) .. T::MaxTopCandidates::get();
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -204,7 +204,7 @@ benchmarks! {
 	}
 
 	force_remove_candidate {
-		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get();
+		let n in (T::MinCollators::get() + 1) .. T::MaxTopCandidates::get();
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -237,7 +237,7 @@ benchmarks! {
 	}
 
 	init_leave_candidates {
-		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get() - 1;
+		let n in (T::MinCollators::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -257,7 +257,7 @@ benchmarks! {
 	}
 
 	cancel_leave_candidates {
-		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get() - 1;
+		let n in (T::MinCollators::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -275,7 +275,7 @@ benchmarks! {
 	}
 
 	execute_leave_candidates {
-		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get() - 1;
+		let n in (T::MinCollators::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 		let u in 1 .. (T::MaxUnstakeRequests::get() as u32 - 1);
 

--- a/pallets/parachain-staking/src/benchmarking.rs
+++ b/pallets/parachain-staking/src/benchmarking.rs
@@ -42,7 +42,7 @@ fn setup_collator_candidates<T: Config>(
 	num_candidates: u32,
 	default_amount: Option<T::CurrencyBalance>,
 ) -> Vec<T::AccountId> {
-	let current_collator_count = CandidatePool::<T>::get().len().saturated_into::<u32>();
+	let current_collator_count = TopCandidates::<T>::get().len().saturated_into::<u32>();
 	let collators: Vec<T::AccountId> = (current_collator_count..num_candidates)
 		.map(|i| account("collator", i.saturated_into::<u32>(), COLLATOR_ACCOUNT_SEED))
 		.collect();
@@ -54,10 +54,10 @@ fn setup_collator_candidates<T: Config>(
 			T::Origin::from(Some(acc.clone()).into()),
 			amount,
 		));
-		assert_eq!(<CandidateState<T>>::get(acc).unwrap().stake, amount);
+		assert_eq!(<CandidatePool<T>>::get(acc).unwrap().stake, amount);
 	}
 
-	CandidatePool::<T>::get()
+	TopCandidates::<T>::get()
 		.into_bounded_vec()
 		.into_inner()
 		.drain(..)
@@ -66,7 +66,7 @@ fn setup_collator_candidates<T: Config>(
 }
 
 fn fill_delegators<T: Config>(num_delegators: u32, collator: T::AccountId, collator_seed: u32) -> Vec<T::AccountId> {
-	let state = <CandidateState<T>>::get(&collator).unwrap();
+	let state = <CandidatePool<T>>::get(&collator).unwrap();
 	let current_delegators = state.delegators.len().saturated_into::<u32>();
 
 	let delegators: Vec<T::AccountId> = (current_delegators..num_delegators)
@@ -215,7 +215,7 @@ benchmarks! {
 		let candidate = candidates[0].clone();
 	}: _(RawOrigin::Root,  T::Lookup::unlookup(candidate.clone()))
 	verify {
-		let candidates = CandidatePool::<T>::get();
+		let candidates = TopCandidates::<T>::get();
 		assert!(!candidates.into_iter().any(|other| other.owner == candidate));
 	}
 
@@ -233,7 +233,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(new_candidate.clone()), T::MinCollatorCandidateStake::get())
 	verify {
-		let candidates = CandidatePool::<T>::get();
+		let candidates = TopCandidates::<T>::get();
 		assert!(candidates.into_iter().any(|other| other.owner == new_candidate));
 	}
 
@@ -251,10 +251,10 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(candidate.clone()))
 	verify {
-		let candidates = CandidatePool::<T>::get();
+		let candidates = TopCandidates::<T>::get();
 		assert!(!candidates.into_iter().any(|other| other.owner == candidate));
 		let unlocking_at = now.saturating_add(T::ExitQueueDelay::get());
-		assert!(<CandidateState<T>>::get(candidate).unwrap().can_exit(unlocking_at));
+		assert!(<CandidatePool<T>>::get(candidate).unwrap().can_exit(unlocking_at));
 	}
 
 	cancel_leave_candidates {
@@ -271,7 +271,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(candidate.clone()))
 	verify {
-		let candidates = CandidatePool::<T>::get();
+		let candidates = TopCandidates::<T>::get();
 		assert!(candidates.into_iter().any(|other| other.owner == candidate));
 	}
 
@@ -321,7 +321,7 @@ benchmarks! {
 		}
 		let candidate = candidates[0].clone();
 
-		let old_stake = <CandidateState<T>>::get(&candidate).unwrap().stake;
+		let old_stake = <CandidatePool<T>>::get(&candidate).unwrap().stake;
 		let more_stake = T::MinCollatorCandidateStake::get();
 
 		// increase stake so we can unstake, because current stake is minimum
@@ -333,7 +333,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(candidate.clone()), more_stake)
 	verify {
-		let new_stake = <CandidateState<T>>::get(&candidate).unwrap().stake;
+		let new_stake = <CandidatePool<T>>::get(&candidate).unwrap().stake;
 		assert!(<Unstaking<T>>::get(candidate).is_empty());
 		assert_eq!(new_stake, old_stake + more_stake + more_stake - T::CurrencyBalance::from(u as u64));
 	}
@@ -349,18 +349,18 @@ benchmarks! {
 		let candidate = candidates[0].clone();
 
 		// increase stake of candidate to later decrease it again
-		let old_stake = <CandidateState<T>>::get(&candidate).unwrap().stake;
+		let old_stake = <CandidatePool<T>>::get(&candidate).unwrap().stake;
 		let more_stake = T::MinCollatorCandidateStake::get();
 
 		T::Currency::make_free_balance_be(&candidate, T::CurrencyBalance::from(u128::MAX));
 		Pallet::<T>::candidate_stake_more(RawOrigin::Signed(candidate.clone()).into(), more_stake).expect("should increase stake");
 
-		let new_stake = <CandidateState<T>>::get(&candidate).unwrap().stake;
+		let new_stake = <CandidatePool<T>>::get(&candidate).unwrap().stake;
 		assert_eq!(new_stake, old_stake + more_stake);
 
 	}: _(RawOrigin::Signed(candidate.clone()), more_stake)
 	verify {
-		let new_stake = <CandidateState<T>>::get(&candidate).unwrap().stake;
+		let new_stake = <CandidatePool<T>>::get(&candidate).unwrap().stake;
 		assert_eq!(new_stake, old_stake);
 	}
 
@@ -379,7 +379,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(delegator.clone()), T::Lookup::unlookup(collator.clone()), amount)
 	verify {
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		assert!(state.delegators.into_iter().any(|x| x.owner == delegator));
 	}
 
@@ -398,7 +398,7 @@ benchmarks! {
 		let amount = T::MinDelegatorStake::get();
 
 		// make sure delegator collated to collator
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		let delegator = state.delegators.into_bounded_vec()[0].owner.clone();
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, amount);
 
@@ -412,7 +412,7 @@ benchmarks! {
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, amount);
 	}: _(RawOrigin::Signed(delegator.clone()), T::Lookup::unlookup(collator.clone()), amount)
 	verify {
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		assert!(state.delegators.into_iter().any(|x| x.owner == delegator));
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, amount + amount);
 		assert!(<Unstaking<T>>::get(&delegator).is_empty());
@@ -432,7 +432,7 @@ benchmarks! {
 		let amount = T::CurrencyBalance::one();
 
 		// make sure delegator collated to collator
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		let delegator = state.delegators.into_bounded_vec()[0].owner.clone();
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, T::MinDelegatorStake::get());
 
@@ -448,7 +448,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(delegator.clone()), T::Lookup::unlookup(collator.clone()), amount)
 	verify {
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		assert!(state.delegators.into_iter().any(|x| x.owner == delegator));
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, T::MinDelegatorStake::get());
 		assert_eq!(<Unstaking<T>>::get(&delegator).len(), 2);
@@ -468,7 +468,7 @@ benchmarks! {
 		let amount = T::CurrencyBalance::one();
 
 		// make sure delegator collated to collator
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		let delegator = state.delegators.into_bounded_vec()[0].owner.clone();
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, T::MinDelegatorStake::get());
 
@@ -484,7 +484,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(delegator.clone()), T::Lookup::unlookup(collator.clone()))
 	verify {
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		assert!(!state.delegators.into_iter().any(|x| x.owner == delegator));
 		assert!(<DelegatorState<T>>::get(&delegator).is_none());
 		assert_eq!(<Unstaking<T>>::get(&delegator).len(), 2);
@@ -504,7 +504,7 @@ benchmarks! {
 		let amount = T::CurrencyBalance::one();
 
 		// make sure delegator collated to collator
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		let delegator = state.delegators.into_bounded_vec()[0].owner.clone();
 		assert_eq!(<DelegatorState<T>>::get(&delegator).unwrap().total, T::MinDelegatorStake::get());
 
@@ -520,7 +520,7 @@ benchmarks! {
 
 	}: _(RawOrigin::Signed(delegator.clone()))
 	verify {
-		let state = <CandidateState<T>>::get(&collator).unwrap();
+		let state = <CandidatePool<T>>::get(&collator).unwrap();
 		assert!(!state.delegators.into_iter().any(|x| x.owner == delegator));
 		assert!(<DelegatorState<T>>::get(&delegator).is_none());
 		assert_eq!(<Unstaking<T>>::get(&delegator).len(), 2);
@@ -544,7 +544,7 @@ benchmarks! {
 
 		// fill unstake BTreeMap by unstaked many entries of 1
 		fill_unstaking::<T>(&candidate, None, u as u64);
-		assert_eq!(<CandidateState<T>>::get(&candidate).unwrap().stake, stake + stake -  T::CurrencyBalance::from(u as u64));
+		assert_eq!(<CandidatePool<T>>::get(&candidate).unwrap().stake, stake + stake -  T::CurrencyBalance::from(u as u64));
 
 		// roll to block in which first unstake can be unlocked
 		System::<T>::set_block_number(T::StakeDuration::get());
@@ -572,17 +572,17 @@ benchmarks! {
 		let old = <MaxCollatorCandidateStake<T>>::get();
 		let candidates = setup_collator_candidates::<T>(n, Some(old));
 		let candidate = candidates[0].clone();
-		assert_eq!(<CandidateState<T>>::get(&candidate).unwrap().stake, old);
+		assert_eq!(<CandidatePool<T>>::get(&candidate).unwrap().stake, old);
 
 		let new =  old.saturating_sub(T::CurrencyBalance::one());
 		for (i, c) in candidates.iter().enumerate() {
 			fill_delegators::<T>(m, c.clone(), i.saturated_into::<u32>());
 		}
-		assert_eq!(<CandidateState<T>>::get(&candidate).unwrap().stake, old);
+		assert_eq!(<CandidatePool<T>>::get(&candidate).unwrap().stake, old);
 	}: decrease_max_candidate_stake_by(RawOrigin::Root, old.saturating_sub(new))
 	verify {
 		assert_eq!(<MaxCollatorCandidateStake<T>>::get(), new);
-		assert_eq!(<CandidateState<T>>::get(candidate).unwrap().stake, new);
+		assert_eq!(<CandidatePool<T>>::get(candidate).unwrap().stake, new);
 	}
 
 	// [Post-launch TODO]: Activate after increasing MaxCollatorsPerDelegator to at least 2. Expected to throw otherwise.
@@ -602,12 +602,12 @@ benchmarks! {
 	// 	let amount = T::MinDelegatorStake::get();
 
 	// 	// make sure delegator collated to collator_delegated
-	// 	let state_delegated = <CandidateState<T>>::get(&collator_delegated).unwrap();
+	// 	let state_delegated = <CandidatePool<T>>::get(&collator_delegated).unwrap();
 	// 	let delegator = state_delegated.delegators.into_bounded_vec()[0].owner.clone();
 	// 	assert!(<DelegatorState<T>>::get(&delegator).is_some());
 
 	// 	// should not have delegated to collator yet
-	// 	let state = <CandidateState<T>>::get(&collator).unwrap();
+	// 	let state = <CandidatePool<T>>::get(&collator).unwrap();
 	// 	assert!(!state.delegators.into_iter().any(|x| x.owner == delegator));
 
 	// 	// increase stake so we can unstake, because current stake is minimum
@@ -619,7 +619,7 @@ benchmarks! {
 
 	// }: _(RawOrigin::Signed(delegator.clone()), T::Lookup::unlookup(collator.clone()), amount)
 	// verify {
-	// 	let state = <CandidateState<T>>::get(&collator).unwrap();
+	// 	let state = <CandidatePool<T>>::get(&collator).unwrap();
 	// 	assert!(state.delegators.into_iter().any(|x| x.owner == delegator);
 	// }
 }

--- a/pallets/parachain-staking/src/benchmarking.rs
+++ b/pallets/parachain-staking/src/benchmarking.rs
@@ -183,7 +183,7 @@ benchmarks! {
 	}
 
 	set_max_selected_candidates {
-		let n in (T::MinSelectedCandidates::get()) .. T::MaxCollatorCandidates::get();
+		let n in (T::MinTopCandidates::get()) .. T::MaxTopCandidates::get();
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -204,7 +204,7 @@ benchmarks! {
 	}
 
 	force_remove_candidate {
-		let n in (T::MinSelectedCandidates::get() + 1) .. T::MaxCollatorCandidates::get();
+		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get();
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -219,7 +219,7 @@ benchmarks! {
 	}
 
 	join_candidates {
-		let n in 1 .. T::MaxCollatorCandidates::get() - 1;
+		let n in 1 .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -237,7 +237,7 @@ benchmarks! {
 	}
 
 	init_leave_candidates {
-		let n in (T::MinSelectedCandidates::get() + 1) .. T::MaxCollatorCandidates::get() - 1;
+		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -257,7 +257,7 @@ benchmarks! {
 	}
 
 	cancel_leave_candidates {
-		let n in (T::MinSelectedCandidates::get() + 1) .. T::MaxCollatorCandidates::get() - 1;
+		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -275,7 +275,7 @@ benchmarks! {
 	}
 
 	execute_leave_candidates {
-		let n in (T::MinSelectedCandidates::get() + 1) .. T::MaxCollatorCandidates::get() - 1;
+		let n in (T::MinTopCandidates::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 		let u in 1 .. (T::MaxUnstakeRequests::get() as u32 - 1);
 
@@ -310,7 +310,7 @@ benchmarks! {
 	}
 
 	candidate_stake_more {
-		let n in 1 .. T::MaxCollatorCandidates::get() - 1;
+		let n in 1 .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 		let u in 0 .. (T::MaxUnstakeRequests::get().saturated_into::<u32>());
 
@@ -338,7 +338,7 @@ benchmarks! {
 	}
 
 	candidate_stake_less {
-		let n in 1 .. T::MaxCollatorCandidates::get() - 1;
+		let n in 1 .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -364,7 +364,7 @@ benchmarks! {
 	}
 
 	join_delegators {
-		let n in 1 .. T::MaxCollatorCandidates::get();
+		let n in 1 .. T::MaxTopCandidates::get();
 		let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
 
 		let candidates = setup_collator_candidates::<T>(n, None);
@@ -384,7 +384,7 @@ benchmarks! {
 
 	delegator_stake_more {
 		// we need at least 1 collators
-		let n in 1 .. T::MaxCollatorCandidates::get();
+		let n in 1 .. T::MaxTopCandidates::get();
 		// we need at least 1 delegator
 		let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
 		let u in 1 .. (T::MaxUnstakeRequests::get().saturated_into::<u32>());
@@ -419,7 +419,7 @@ benchmarks! {
 
 	delegator_stake_less {
 		// we need at least 1 collators
-		let n in 1 .. T::MaxCollatorCandidates::get();
+		let n in 1 .. T::MaxTopCandidates::get();
 		// we need at least 1 delegator
 		let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
 
@@ -455,7 +455,7 @@ benchmarks! {
 
 	revoke_delegation {
 		// we need at least 1 collators
-		let n in 1 .. T::MaxCollatorCandidates::get();
+		let n in 1 .. T::MaxTopCandidates::get();
 		// we need at least 1 delegator
 		let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
 
@@ -491,7 +491,7 @@ benchmarks! {
 
 	leave_delegators {
 		// we need at least 1 collators
-		let n in 1 .. T::MaxCollatorCandidates::get();
+		let n in 1 .. T::MaxTopCandidates::get();
 		// we need at least 1 delegator
 		let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
 
@@ -566,7 +566,7 @@ benchmarks! {
 	// [Post-launch TODO]: Activate after increasing MaxCollatorsPerDelegator to at least 2. Expected to throw otherwise.
 	// delegate_another_candidate {
 	// 	// we need at least 2 collators
-	// 	let n in 2 .. T::MaxCollatorCandidates::get();
+	// 	let n in 2 .. T::MaxTopCandidates::get();
 	// 	// we need at least 1 delegator
 	// 	let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
 	// 	let u in 0 .. (T::MaxUnstakeRequests::get().saturated_into::<u32>());

--- a/pallets/parachain-staking/src/default_weights.rs
+++ b/pallets/parachain-staking/src/default_weights.rs
@@ -66,8 +66,7 @@ pub trait WeightInfo {
 	fn revoke_delegation(n: u32, m: u32, ) -> Weight;
 	fn leave_delegators(n: u32, m: u32, ) -> Weight;
 	fn unlock_unstaked(u: u32, ) -> Weight;
-	fn increase_max_candidate_stake_by() -> Weight;
-	fn decrease_max_candidate_stake_by(n: u32, m: u32, ) -> Weight;
+	fn set_max_candidate_stake() -> Weight;
 }
 
 /// Weights for parachain_staking using the Substrate node and recommended hardware.
@@ -235,19 +234,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	fn increase_max_candidate_stake_by() -> Weight {
+	fn set_max_candidate_stake() -> Weight {
 		(29_014_000_u64)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	fn decrease_max_candidate_stake_by(n: u32, m: u32, ) -> Weight {
-		(0_u64)
-			// Standard Error: 128_000
-			.saturating_add((63_038_000_u64).saturating_mul(n as Weight))
-			// Standard Error: 452_000
-			.saturating_add((39_172_000_u64).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads((3_u64).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes((3_u64).saturating_mul(n as Weight)))
 	}
 }
 
@@ -415,18 +405,9 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
-	fn increase_max_candidate_stake_by() -> Weight {
+	fn set_max_candidate_stake() -> Weight {
 		(29_014_000_u64)
 			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
-	}
-	fn decrease_max_candidate_stake_by(n: u32, m: u32, ) -> Weight {
-		(0_u64)
-			// Standard Error: 128_000
-			.saturating_add((63_038_000_u64).saturating_mul(n as Weight))
-			// Standard Error: 452_000
-			.saturating_add((39_172_000_u64).saturating_mul(m as Weight))
-			.saturating_add(RocksDbWeight::get().reads((3_u64).saturating_mul(n as Weight)))
-			.saturating_add(RocksDbWeight::get().writes((3_u64).saturating_mul(n as Weight)))
 	}
 }

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2139,23 +2139,25 @@ pub mod pallet {
 					}
 				})?;
 
-			// update total stake
-			state.total = state
-				.total
-				.saturating_sub(stake_to_remove.amount)
-				.saturating_add(stake.amount);
+			if let Some(stake_to_remove) = stake_to_remove {
+				// update total stake
+				state.total = state
+					.total
+					.saturating_sub(stake_to_remove.amount)
+					.saturating_add(stake.amount);
 
-			// update storage of kicked delegator
-			Self::kick_delegator(&stake_to_remove, &state.id)?;
+				// update storage of kicked delegator
+				Self::kick_delegator(&stake_to_remove, &state.id)?;
 
-			Self::deposit_event(Event::DelegationReplaced(
-				stake.owner,
-				stake.amount,
-				stake_to_remove.owner,
-				stake_to_remove.amount,
-				state.id.clone(),
-				state.total,
-			));
+				Self::deposit_event(Event::DelegationReplaced(
+					stake.owner,
+					stake.amount,
+					stake_to_remove.owner,
+					stake_to_remove.amount,
+					state.id.clone(),
+					state.total,
+				));
+			}
 
 			Ok(state)
 		}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -594,7 +594,7 @@ pub mod pallet {
 	pub(crate) type CandidateCount<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	/// Total funds locked to back the currently selected collators.
-	/// The sum of all the delegator stake and collator stake.
+	/// The sum of all collator and their delegator stakes.
 	///
 	/// Note: There are more funds locked by this pallet, since the backing for
 	/// non collating candidates is not included in [TotalCollatorStake].

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1184,20 +1184,20 @@ pub mod pallet {
 			T::MaxDelegatorsPerCollator::get(),
 		))]
 		pub fn cancel_leave_candidates(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
-			let collator = ensure_signed(origin)?;
-			let mut state = <CandidatePool<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let candidate = ensure_signed(origin)?;
+			let mut state = <CandidatePool<T>>::get(&candidate).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(state.is_leaving(), Error::<T>::NotLeaving);
 
 			// revert leaving state
 			state.revert_leaving();
 
-			Self::update_top_candidates(collator.clone(), state.total, state.total);
+			Self::update_top_candidates(candidate.clone(), state.total, state.total);
 
 			// update candidates for next round
-			<CandidatePool<T>>::insert(&collator, state);
+			<CandidatePool<T>>::insert(&candidate, state);
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
 
-			Self::deposit_event(Event::CollatorCanceledExit(collator));
+			Self::deposit_event(Event::CollatorCanceledExit(candidate));
 			Ok(Some(<T as pallet::Config>::WeightInfo::cancel_leave_candidates(
 				num_collators,
 				num_delegators,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1315,9 +1315,6 @@ pub mod pallet {
 			if state.is_active() {
 				Self::update_top_candidates(collator.clone(), before, state.total);
 			}
-
-			Self::update_top_candidates(collator.clone(), before, state.total);
-
 			<CandidatePool<T>>::insert(&collator, state);
 
 			// update candidates for next round

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2131,12 +2131,11 @@ pub mod pallet {
 					}
 				})?;
 
+			state.total = state.total.saturating_add(stake.amount);
+
 			if let Some(stake_to_remove) = stake_to_remove {
 				// update total stake
-				state.total = state
-					.total
-					.saturating_sub(stake_to_remove.amount)
-					.saturating_add(stake.amount);
+				state.total = state.total.saturating_sub(stake_to_remove.amount);
 
 				// update storage of kicked delegator
 				Self::kick_delegator(&stake_to_remove, &state.id)?;

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -266,7 +266,7 @@ pub mod pallet {
 		/// Minimum number of collators selected from the set of candidates at
 		/// every validation round.
 		#[pallet::constant]
-		type MinTopCandidates: Get<u32>;
+		type MinCollators: Get<u32>;
 
 		/// Minimum number of collators which cannot leave the network if there
 		/// are no others.
@@ -704,7 +704,7 @@ pub mod pallet {
 				}
 			}
 			// Set total selected candidates to minimum config
-			<MaxSelectedCandidates<T>>::put(T::MinTopCandidates::get());
+			<MaxSelectedCandidates<T>>::put(T::MinCollators::get());
 
 			// Choose top MaxSelectedCandidates collator candidates
 			<Pallet<T>>::update_total_stake();
@@ -813,7 +813,7 @@ pub mod pallet {
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_max_selected_candidates(*new, (*new).saturating_mul(T::MaxDelegatorsPerCollator::get())))]
 		pub fn set_max_selected_candidates(origin: OriginFor<T>, new: u32) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			ensure!(new >= T::MinTopCandidates::get(), Error::<T>::CannotSetBelowMin);
+			ensure!(new >= T::MinCollators::get(), Error::<T>::CannotSetBelowMin);
 			let old = <MaxSelectedCandidates<T>>::get();
 			<MaxSelectedCandidates<T>>::put(new);
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1011,7 +1011,7 @@ pub mod pallet {
 			Self::increase_lock(&sender, stake, BalanceOf::<T>::zero())?;
 
 			let candidate = Candidate::new(sender.clone(), stake);
-			<CandidatePool<T>>::insert(&sender, candidate);
+			CandidatePool::<T>::insert(&sender, candidate);
 			Self::update_top_candidates(sender.clone(), BalanceOf::<T>::zero(), stake);
 
 			CandidateCount::<T>::mutate(|count| {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -71,8 +71,10 @@
 //!
 //! ### Terminology
 //!
-//! - **Collator:** A user which locks up tokens to be included into the set of
+//! - **Candidate:** A user which locks up tokens to be included into the set of
 //!   authorities which author blocks and receive rewards for doing so.
+//!
+//! - **Collator:** A candidate that was chosen to collate this round.
 //!
 //! - **Delegator:** A user which locks up tokens for collators they trust. When
 //!   their collator authors a block, the corresponding delegators also receive
@@ -530,7 +532,7 @@ pub mod pallet {
 	/// True if network has been upgraded to this version.
 	/// Storage version of the pallet.
 	///
-	/// This is set to v2.0.0 for new networks.
+	/// This is set to v4 for new networks.
 	#[pallet::storage]
 	pub(crate) type StorageVersion<T: Config> = StorageValue<_, StakingStorageVersion, ValueQuery>;
 
@@ -580,9 +582,7 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
-	/// The staking information for a candidate.
-	///
-	/// It maps from an account to its information.
+	/// The number of candidates in the pool.
 	#[pallet::storage]
 	#[pallet::getter(fn candidate_count)]
 	pub(crate) type CandidateCount<T: Config> = StorageValue<_, u32, ValueQuery>;
@@ -591,7 +591,7 @@ pub mod pallet {
 	/// The sum of all the delegator stake and collator stake.
 	///
 	/// Note: There are more funds locked by this pallet, since the backing for
-	/// candidates (non collating) is not included in [TotalCollatorStake].
+	/// non collating candidates is not included in [TotalCollatorStake].
 	#[pallet::storage]
 	#[pallet::getter(fn total_collator_stake)]
 	pub(crate) type TotalCollatorStake<T: Config> = StorageValue<_, TotalStake<BalanceOf<T>>, ValueQuery>;
@@ -602,6 +602,9 @@ pub mod pallet {
 	/// pushes another candidate out of the list. When the stake is reduced, it
 	/// is not checked of another candidate has more stake, since this would
 	/// require the iterating over the [CandidatePool].
+	///
+	/// There must always be more candidates than [MaxSelectedCandidates] so
+	/// that a collator can drop out of the collator set by reducing his stake.
 	#[pallet::storage]
 	#[pallet::getter(fn top_candidates)]
 	pub(crate) type TopCandidates<T: Config> =

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -52,7 +52,7 @@ pub enum StakingStorageVersion {
 	V1_0_0,
 	V2_0_0, // New Reward calculation, MaxCollatorCandidateStake
 	V3_0_0, // Update InflationConfig
-	V4,     // Sort CandidatePool and parachain-stakings by amount
+	V4,     // Sort TopCandidates and parachain-stakings by amount
 }
 
 #[cfg(feature = "try-runtime")]

--- a/pallets/parachain-staking/src/migrations/v4.rs
+++ b/pallets/parachain-staking/src/migrations/v4.rs
@@ -19,7 +19,7 @@
 use crate::{
 	migrations::StakingStorageVersion,
 	types::{CandidateOf, Delegator},
-	CandidatePool, CandidateState, Config, DelegatorState, StorageVersion,
+	TopCandidates, CandidatePool, Config, DelegatorState, StorageVersion,
 };
 use frame_support::{dispatch::Weight, traits::Get};
 
@@ -33,11 +33,11 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	log::info!("Migrating staking to StakingStorageVersion::V4");
 
 	// sort candidates from greatest to lowest
-	CandidatePool::<T>::mutate(|candidates| candidates.sort_greatest_to_lowest());
+	TopCandidates::<T>::mutate(|candidates| candidates.sort_greatest_to_lowest());
 	let mut n = 1u64;
 
 	// for each candidate: sort delegators from greatest to lowest
-	CandidateState::<T>::translate_values(|mut state: CandidateOf<T, T::MaxDelegatorsPerCollator>| {
+	CandidatePool::<T>::translate_values(|mut state: CandidateOf<T, T::MaxDelegatorsPerCollator>| {
 		state.delegators.sort_greatest_to_lowest();
 		n = n.saturating_add(1u64);
 		Some(state)
@@ -60,10 +60,10 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 
 #[cfg(feature = "try-runtime")]
 pub(crate) fn post_migrate<T: Config>() -> Result<(), &'static str> {
-	let mut candidates = CandidatePool::<T>::get();
+	let mut candidates = TopCandidates::<T>::get();
 	candidates.sort_greatest_to_lowest();
 	assert_eq!(
-		CandidatePool::<T>::get().into_bounded_vec().into_inner(),
+		TopCandidates::<T>::get().into_bounded_vec().into_inner(),
 		candidates.into_bounded_vec().into_inner()
 	);
 	assert_eq!(StorageVersion::<T>::get(), StakingStorageVersion::V4);

--- a/pallets/parachain-staking/src/migrations/v4.rs
+++ b/pallets/parachain-staking/src/migrations/v4.rs
@@ -19,7 +19,7 @@
 use crate::{
 	migrations::StakingStorageVersion,
 	types::{CandidateOf, Delegator},
-	TopCandidates, CandidatePool, Config, DelegatorState, StorageVersion,
+	CandidatePool, Config, DelegatorState, StorageVersion, TopCandidates,
 };
 use frame_support::{dispatch::Weight, traits::Get};
 

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -130,7 +130,7 @@ parameter_types! {
 	pub const StakeDuration: u32 = 2;
 	pub const ExitQueueDelay: u32 = 2;
 	pub const DefaultBlocksPerRound: BlockNumber = BLOCKS_PER_ROUND;
-	pub const MinTopCandidates: u32 = 2;
+	pub const MinCollators: u32 = 2;
 	#[derive(Debug, PartialEq)]
 	pub const MaxDelegatorsPerCollator: u32 = 4;
 	#[derive(Debug, PartialEq)]
@@ -152,8 +152,8 @@ impl Config for Test {
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type StakeDuration = StakeDuration;
 	type ExitQueueDelay = ExitQueueDelay;
-	type MinTopCandidates = MinTopCandidates;
-	type MinRequiredCollators = MinTopCandidates;
+	type MinCollators = MinCollators;
+	type MinRequiredCollators = MinCollators;
 	type MaxDelegationsPerRound = MaxDelegatorsPerCollator;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;
 	type MaxCollatorsPerDelegator = MaxCollatorsPerDelegator;

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -130,7 +130,7 @@ parameter_types! {
 	pub const StakeDuration: u32 = 2;
 	pub const ExitQueueDelay: u32 = 2;
 	pub const DefaultBlocksPerRound: BlockNumber = BLOCKS_PER_ROUND;
-	pub const MinSelectedCandidates: u32 = 2;
+	pub const MinTopCandidates: u32 = 2;
 	#[derive(Debug, PartialEq)]
 	pub const MaxDelegatorsPerCollator: u32 = 4;
 	#[derive(Debug, PartialEq)]
@@ -152,14 +152,14 @@ impl Config for Test {
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type StakeDuration = StakeDuration;
 	type ExitQueueDelay = ExitQueueDelay;
-	type MinSelectedCandidates = MinSelectedCandidates;
-	type MinRequiredCollators = MinSelectedCandidates;
+	type MinTopCandidates = MinTopCandidates;
+	type MinRequiredCollators = MinTopCandidates;
 	type MaxDelegationsPerRound = MaxDelegatorsPerCollator;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;
 	type MaxCollatorsPerDelegator = MaxCollatorsPerDelegator;
 	type MinCollatorStake = MinCollatorStake;
 	type MinCollatorCandidateStake = MinCollatorStake;
-	type MaxCollatorCandidates = MaxCollatorCandidates;
+	type MaxTopCandidates = MaxCollatorCandidates;
 	type MinDelegatorStake = MinDelegatorStake;
 	type MinDelegation = MinDelegation;
 	type MaxUnstakeRequests = MaxUnstakeRequests;

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -56,7 +56,8 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 		Self(bv)
 	}
 
-	/// TODO: doc
+	/// Mutate the set without restrictions. After the set was mutated it will
+	/// be resorted and deduplicated.
 	pub fn mutate<F: FnOnce(&mut BoundedVec<T, S>)>(&mut self, function: F) {
 		function(&mut self.0);
 		(self.0[..]).sort_by(|a, b| b.cmp(a));

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -62,13 +62,14 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 		(self.0[..]).sort_by(|a, b| b.cmp(a));
 
 		// TODO: add dedup to BoundedVec
-		let mut i = 0;
+		let mut i: usize = 0;
 		let mut next = i.saturating_add(1);
 		while next < self.len() {
 			if self[i] == self[next] {
 				self.0.remove(next);
 			} else {
 				i = next;
+				next = next.saturating_add(1);
 			}
 		}
 	}

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -106,8 +106,8 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 	pub fn try_insert_replace(&mut self, value: T) -> Result<Option<T>, bool> {
 		// the highest allowed index
 		let highest_index: usize = S::get().saturating_sub(1).saturated_into();
-		if highest_index.is_zero() {
-			return Err(false);
+		if S::get().is_zero() {
+			return Err(true);
 		}
 		match self.try_insert(value.clone()) {
 			Err(loc) if loc <= highest_index => {
@@ -285,6 +285,10 @@ mod tests {
 
 	parameter_types! {
 		#[derive(PartialEq, RuntimeDebug)]
+		pub const Zero: u32 = 0;
+		#[derive(PartialEq, RuntimeDebug)]
+		pub const One: u32 = 1;
+		#[derive(PartialEq, RuntimeDebug)]
 		pub const Eight: u32 = 8;
 		#[derive(PartialEq, RuntimeDebug, Clone)]
 		pub const Five: u32 = 5;
@@ -364,6 +368,14 @@ mod tests {
 
 	#[test]
 	fn try_insert_replace() {
+		let mut set: OrderedSet<i32, Zero> = OrderedSet::from(vec![].try_into().unwrap());
+		assert_eq!(set.try_insert_replace(10), Err(true));
+
+		let mut set: OrderedSet<i32, One> = OrderedSet::from(vec![].try_into().unwrap());
+		assert_eq!(set.try_insert_replace(10), Ok(None));
+		assert_eq!(set.try_insert_replace(9), Err(true));
+		assert_eq!(set.try_insert_replace(11), Ok(Some(10)));
+
 		let mut set: OrderedSet<i32, Five> = OrderedSet::from(vec![].try_into().unwrap());
 		assert_eq!(set.try_insert_replace(10), Ok(None));
 		assert_eq!(set.try_insert_replace(7), Ok(None));

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -63,11 +63,12 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 
 		// TODO: add dedup to BoundedVec
 		let mut i = 0;
-		while (i + 1) < self.len() {
-			if self[i] == self[i + 1] {
-				self.0.remove(i + 1);
+		let mut next = i.saturating_add(1);
+		while next < self.len() {
+			if self[i] == self[next] {
+				self.0.remove(next);
 			} else {
-				i += 1;
+				i = next;
 			}
 		}
 	}

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -113,7 +113,9 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 			Err(loc) if loc <= highest_index => {
 				// always replace the last element
 				let last_idx = self.len().saturating_sub(1);
-				// accessing by index wont panic since we checked the index
+				// accessing by index wont panic since we checked the index, inserting the item
+				// at the end of the list to ensure last-in-least-priority-rule for collators.
+				// sorting algorithm must be stable!
 				let old = sp_std::mem::replace(&mut self.0[last_idx], value);
 				self.sort_greatest_to_lowest();
 				Ok(Some(old))

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -1960,7 +1960,7 @@ fn reach_max_top_candidates() {
 		.execute_with(|| {
 			assert_eq!(
 				StakePallet::top_candidates().len().saturated_into::<u32>(),
-				<Test as Config>::MaxCollatorCandidates::get()
+				<Test as Config>::MaxTopCandidates::get()
 			);
 			// should not be possible to join candidate pool, even with more stake
 			assert_ok!(StakePallet::join_candidates(Origin::signed(11), 11));
@@ -2137,10 +2137,7 @@ fn set_max_selected_candidates() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				StakePallet::set_max_selected_candidates(
-					Origin::root(),
-					<Test as Config>::MinCollators::get() - 1
-				),
+				StakePallet::set_max_selected_candidates(Origin::root(), <Test as Config>::MinCollators::get() - 1),
 				Error::<Test>::CannotSetBelowMin
 			);
 			assert_ok!(StakePallet::set_max_selected_candidates(

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -187,7 +187,7 @@ fn genesis() {
 			// Safety first checks
 			assert_eq!(
 				StakePallet::max_selected_candidates(),
-				<Test as Config>::MinTopCandidates::get()
+				<Test as Config>::MinCollators::get()
 			);
 			assert_eq!(
 				StakePallet::round(),
@@ -251,7 +251,7 @@ fn genesis() {
 			// Safety first checks
 			assert_eq!(
 				StakePallet::max_selected_candidates(),
-				<Test as Config>::MinTopCandidates::get()
+				<Test as Config>::MinCollators::get()
 			);
 			assert_eq!(
 				StakePallet::round(),
@@ -2139,13 +2139,13 @@ fn set_max_selected_candidates() {
 			assert_noop!(
 				StakePallet::set_max_selected_candidates(
 					Origin::root(),
-					<Test as Config>::MinTopCandidates::get() - 1
+					<Test as Config>::MinCollators::get() - 1
 				),
 				Error::<Test>::CannotSetBelowMin
 			);
 			assert_ok!(StakePallet::set_max_selected_candidates(
 				Origin::root(),
-				<Test as Config>::MinTopCandidates::get() + 1
+				<Test as Config>::MinCollators::get() + 1
 			));
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -398,6 +398,7 @@ fn collator_exit_executes_after_delay() {
 				Event::MaxSelectedCandidatesSet(2, 5),
 				Event::NewRound(5, 1),
 				Event::NewRound(10, 2),
+				Event::LeftTopCandidates(2),
 				Event::CollatorChosen(1, 500, 200),
 				Event::CollatorChosen(7, 100, 0),
 				Event::CollatorScheduledExit(2, 2, 4),
@@ -469,6 +470,7 @@ fn collator_selection_chooses_top_candidates() {
 				Event::CollatorChosen(5, 60, 0),
 				Event::MaxSelectedCandidatesSet(2, 5),
 				Event::NewRound(5, 1),
+				Event::LeftTopCandidates(6),
 				Event::CollatorChosen(1, 100, 0),
 				Event::CollatorChosen(2, 90, 0),
 				Event::CollatorChosen(3, 80, 0),
@@ -480,6 +482,7 @@ fn collator_selection_chooses_top_candidates() {
 				Event::NewRound(15, 3),
 				Event::CollatorLeft(6, 50),
 				Event::NewRound(20, 4),
+				Event::EnteredTopCandidates(6),
 				Event::CollatorChosen(1, 100, 0),
 				Event::CollatorChosen(2, 90, 0),
 				Event::CollatorChosen(3, 80, 0),
@@ -565,6 +568,7 @@ fn exit_queue_with_events() {
 
 			roll_to(30, vec![]);
 			let mut new_events = vec![
+				Event::LeftTopCandidates(6),
 				Event::CollatorChosen(1, 100, 0),
 				Event::CollatorChosen(2, 90, 0),
 				Event::CollatorChosen(3, 80, 0),
@@ -572,6 +576,7 @@ fn exit_queue_with_events() {
 				Event::CollatorChosen(5, 60, 0),
 				Event::CollatorScheduledExit(1, 6, 3),
 				Event::NewRound(10, 2),
+				Event::LeftTopCandidates(5),
 				Event::CollatorChosen(1, 100, 0),
 				Event::CollatorChosen(2, 90, 0),
 				Event::CollatorChosen(3, 80, 0),
@@ -579,6 +584,7 @@ fn exit_queue_with_events() {
 				Event::CollatorScheduledExit(2, 5, 4),
 				Event::NewRound(15, 3),
 				Event::CollatorLeft(6, 50),
+				Event::LeftTopCandidates(4),
 				Event::CollatorChosen(1, 100, 0),
 				Event::CollatorChosen(2, 90, 0),
 				Event::CollatorChosen(3, 80, 0),
@@ -1056,6 +1062,7 @@ fn multiple_delegations() {
 
 			roll_to(31, vec![]);
 			let mut new3 = vec![
+				Event::LeftTopCandidates(2),
 				Event::CollatorChosen(1, 20, 30),
 				Event::CollatorChosen(4, 20, 10),
 				Event::CollatorChosen(3, 20, 10),

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -187,7 +187,7 @@ fn genesis() {
 			// Safety first checks
 			assert_eq!(
 				StakePallet::max_selected_candidates(),
-				<Test as Config>::MinSelectedCandidates::get()
+				<Test as Config>::MinTopCandidates::get()
 			);
 			assert_eq!(
 				StakePallet::round(),
@@ -251,7 +251,7 @@ fn genesis() {
 			// Safety first checks
 			assert_eq!(
 				StakePallet::max_selected_candidates(),
-				<Test as Config>::MinSelectedCandidates::get()
+				<Test as Config>::MinTopCandidates::get()
 			);
 			assert_eq!(
 				StakePallet::round(),
@@ -2139,13 +2139,13 @@ fn set_max_selected_candidates() {
 			assert_noop!(
 				StakePallet::set_max_selected_candidates(
 					Origin::root(),
-					<Test as Config>::MinSelectedCandidates::get() - 1
+					<Test as Config>::MinTopCandidates::get() - 1
 				),
 				Error::<Test>::CannotSetBelowMin
 			);
 			assert_ok!(StakePallet::set_max_selected_candidates(
 				Origin::root(),
-				<Test as Config>::MinSelectedCandidates::get() + 1
+				<Test as Config>::MinTopCandidates::get() + 1
 			));
 		});
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -2576,6 +2576,14 @@ fn candidate_leaves() {
 				Error::<Test>::CannotDelegateIfLeaving
 			);
 			assert_noop!(
+				StakePallet::candidate_stake_less(Origin::signed(1), 1),
+				Error::<Test>::CannotStakeIfLeaving
+			);
+			assert_noop!(
+				StakePallet::candidate_stake_more(Origin::signed(1), 1),
+				Error::<Test>::CannotStakeIfLeaving
+			);
+			assert_noop!(
 				StakePallet::init_leave_candidates(Origin::signed(1)),
 				Error::<Test>::AlreadyLeaving
 			);

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -238,7 +238,7 @@ where
 	/// doesn't insert the new delegation.
 	pub fn add_delegation(&mut self, stake: Stake<AccountId, Balance>) -> Result<bool, ()> {
 		let amt = stake.amount;
-		if self.delegations.try_insert(stake)? {
+		if self.delegations.try_insert(stake).map_err(|_| ())? {
 			self.total = self.total.saturating_add(amt);
 			Ok(true)
 		} else {

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -747,7 +747,7 @@ parameter_types! {
 	/// Collator exit requests are delayed by 4 (2 rounds/sessions)
 	pub const ExitQueueDelay: u32 = 2;
 	/// Minimum 16 collators selected per round, default at genesis and minimum forever after
-	pub const MinTopCandidates: u32 = MIN_COLLATORS;
+	pub const MinCollators: u32 = MIN_COLLATORS;
 	/// At least 4 candidates which cannot leave the network if there are no other candidates.
 	pub const MinRequiredCollators: u32 = 4;
 	/// We only allow one delegation per round.
@@ -777,7 +777,7 @@ impl parachain_staking::Config for Runtime {
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type StakeDuration = StakeDuration;
 	type ExitQueueDelay = ExitQueueDelay;
-	type MinTopCandidates = MinTopCandidates;
+	type MinCollators = MinCollators;
 	type MinRequiredCollators = MinRequiredCollators;
 	type MaxDelegationsPerRound = MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -747,7 +747,7 @@ parameter_types! {
 	/// Collator exit requests are delayed by 4 (2 rounds/sessions)
 	pub const ExitQueueDelay: u32 = 2;
 	/// Minimum 16 collators selected per round, default at genesis and minimum forever after
-	pub const MinSelectedCandidates: u32 = MIN_COLLATORS;
+	pub const MinTopCandidates: u32 = MIN_COLLATORS;
 	/// At least 4 candidates which cannot leave the network if there are no other candidates.
 	pub const MinRequiredCollators: u32 = 4;
 	/// We only allow one delegation per round.
@@ -777,14 +777,14 @@ impl parachain_staking::Config for Runtime {
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type StakeDuration = StakeDuration;
 	type ExitQueueDelay = ExitQueueDelay;
-	type MinSelectedCandidates = MinSelectedCandidates;
+	type MinTopCandidates = MinTopCandidates;
 	type MinRequiredCollators = MinRequiredCollators;
 	type MaxDelegationsPerRound = MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;
 	type MaxCollatorsPerDelegator = MaxCollatorsPerDelegator;
 	type MinCollatorStake = MinCollatorStake;
 	type MinCollatorCandidateStake = MinCollatorStake;
-	type MaxCollatorCandidates = MaxCollatorCandidates;
+	type MaxTopCandidates = MaxCollatorCandidates;
 	type MinDelegation = MinDelegatorStake;
 	type MinDelegatorStake = MinDelegatorStake;
 	type MaxUnstakeRequests = MaxUnstakeRequests;

--- a/runtimes/peregrine/src/weights/parachain_staking.rs
+++ b/runtimes/peregrine/src/weights/parachain_staking.rs
@@ -212,18 +212,9 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	fn increase_max_candidate_stake_by() -> Weight {
+	fn set_max_candidate_stake() -> Weight {
 		(25_518_000_u64)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	fn decrease_max_candidate_stake_by(n: u32, m: u32, ) -> Weight {
-		(0_u64)
-			// Standard Error: 128_000
-			.saturating_add((59_819_000_u64).saturating_mul(n as Weight))
-			// Standard Error: 452_000
-			.saturating_add((36_894_000_u64).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads((3_u64).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes((3_u64).saturating_mul(n as Weight)))
 	}
 }

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -344,7 +344,7 @@ parameter_types! {
 	/// Collator exit requests are delayed by 4 hours (2 rounds/sessions)
 	pub const ExitQueueDelay: u32 = 2;
 	/// Minimum 16 collators selected per round, default at genesis and minimum forever after
-	pub const MinTopCandidates: u32 = 16;
+	pub const MinCollators: u32 = 16;
 	/// At least 4 candidates which cannot leave the network if there are no other candidates.
 	pub const MinRequiredCollators: u32 = 4;
 	/// We only allow one delegation per round.
@@ -374,7 +374,7 @@ impl parachain_staking::Config for Runtime {
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type StakeDuration = StakeDuration;
 	type ExitQueueDelay = ExitQueueDelay;
-	type MinTopCandidates = MinTopCandidates;
+	type MinCollators = MinCollators;
 	type MinRequiredCollators = MinRequiredCollators;
 	type MaxDelegationsPerRound = MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -344,7 +344,7 @@ parameter_types! {
 	/// Collator exit requests are delayed by 4 hours (2 rounds/sessions)
 	pub const ExitQueueDelay: u32 = 2;
 	/// Minimum 16 collators selected per round, default at genesis and minimum forever after
-	pub const MinSelectedCandidates: u32 = 16;
+	pub const MinTopCandidates: u32 = 16;
 	/// At least 4 candidates which cannot leave the network if there are no other candidates.
 	pub const MinRequiredCollators: u32 = 4;
 	/// We only allow one delegation per round.
@@ -374,14 +374,14 @@ impl parachain_staking::Config for Runtime {
 	type DefaultBlocksPerRound = DefaultBlocksPerRound;
 	type StakeDuration = StakeDuration;
 	type ExitQueueDelay = ExitQueueDelay;
-	type MinSelectedCandidates = MinSelectedCandidates;
+	type MinTopCandidates = MinTopCandidates;
 	type MinRequiredCollators = MinRequiredCollators;
 	type MaxDelegationsPerRound = MaxDelegationsPerRound;
 	type MaxDelegatorsPerCollator = MaxDelegatorsPerCollator;
 	type MaxCollatorsPerDelegator = MaxCollatorsPerDelegator;
 	type MinCollatorStake = MinCollatorStake;
 	type MinCollatorCandidateStake = MinCollatorStake;
-	type MaxCollatorCandidates = MaxCollatorCandidates;
+	type MaxTopCandidates = MaxCollatorCandidates;
 	type MinDelegation = MinDelegatorStake;
 	type MinDelegatorStake = MinDelegatorStake;
 	type MaxUnstakeRequests = MaxUnstakeRequests;

--- a/runtimes/spiritnet/src/weights/parachain_staking.rs
+++ b/runtimes/spiritnet/src/weights/parachain_staking.rs
@@ -212,18 +212,9 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	fn increase_max_candidate_stake_by() -> Weight {
+	fn set_max_candidate_stake() -> Weight {
 		(25_518_000_u64)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
-	}
-	fn decrease_max_candidate_stake_by(n: u32, m: u32, ) -> Weight {
-		(0_u64)
-			// Standard Error: 128_000
-			.saturating_add((59_819_000_u64).saturating_mul(n as Weight))
-			// Standard Error: 452_000
-			.saturating_add((36_894_000_u64).saturating_mul(m as Weight))
-			.saturating_add(T::DbWeight::get().reads((3_u64).saturating_mul(n as Weight)))
-			.saturating_add(T::DbWeight::get().writes((3_u64).saturating_mul(n as Weight)))
 	}
 }


### PR DESCRIPTION
## fixes KILTprotocol/srlabs-audit/issues/2

* remove 'cache' for selected candidates, calculate on the fly
* replace {increase, decrease}_max_candidate_stake with simple set_max_candidate_stake
  * don't adjust existing collator stake. If root wants to adjust the stake, they need to adjust the existing stake manually with root calls. 

### todo

- [ ] storage migration: remove `selected_candidate` list
- [ ] storage migration: initialize `CandidateCount`
- [x] Events: enter & leave top candidates
- [ ] optimization: don't iter over collators to update total stake

### custom types

This PR introduces new custom JS-types which are required for compatibility with [our SDK](https://github.com/KILTprotocol/sdk-js) and the [Polkadot Apps](https://polkadot.js.org/apps/#/extrinsics). Please use the following types to test the code with the Polkadot Apps:

<details>
  <summary>JS-Types</summary>
  
  ```js
{
  Candidate: {
    id: "AccountId",
    stake: "Balance",

    delegators: "Vec<Stake>",
    total: "Balance",
    state: "CollatorStatus",
  },
  CandidateOf: "Candidate",
  Collator: undefined,
  CollatorOf: undefined,
}
  ```
</details>

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
