### PR TITLE
refactor: staking

### DIFF
--- a/pallets/parachain-staking/src/benchmarking.rs
+++ b/pallets/parachain-staking/src/benchmarking.rs
@@ -192,12 +192,9 @@ benchmarks! {
 			fill_delegators::<T>(m, c.clone(), i.saturated_into::<u32>());
 		}
 		let old_candidate = candidates[0].clone();
-		let old_num_selected = <SelectedCandidates<T>>::get().len();
 	}: _(RawOrigin::Root, n)
 	verify {
 		assert_eq!(<MaxSelectedCandidates<T>>::get(), n);
-		assert_eq!(<SelectedCandidates<T>>::get().len().saturated_into::<u32>(), n);
-		assert_eq!(<SelectedCandidates<T>>::get().len(), old_num_selected + ((n - T::MinSelectedCandidates::get()) as usize));
 	}
 
 	set_blocks_per_round {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1939,18 +1939,6 @@ pub mod pallet {
 			}
 		}
 
-		/// Check whether an account is currently among the selected collator
-		/// candidates for the current validation round.
-		///
-		/// # <weight>
-		/// Weight: O(N) where N is the number SelectedCandidates bounded by
-		/// `MaxCollatorCandidates`.
-		/// - Reads: SelectedCandidates
-		/// # </weight>
-		pub fn is_selected_candidate(acc: &T::AccountId) -> bool {
-			<SelectedCandidates<T>>::get().binary_search(acc).is_ok()
-		}
-
 		/// Update the staking information for an active collator candidate.
 		///
 		/// NOTE: it is assumed that the calling context checks whether the

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -21,7 +21,7 @@ use parity_scale_codec::{Decode, Encode};
 use sp_std::{
 	cmp::Ordering,
 	convert::TryInto,
-	ops::{Index, IndexMut, Range, RangeFull},
+	ops::{Index, Range, RangeFull},
 };
 #[cfg(feature = "std")]
 use sp_std::{fmt, prelude::*};

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -55,6 +55,20 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 		Self(bv)
 	}
 
+	///
+	pub fn mutate<F: FnOnce(&mut BoundedVec<T, S>)>(&mut self, function: F) {
+		function(&mut self.0);
+		(self.0[..]).sort_by(|a, b| b.cmp(a));
+		let mut i = 0;
+		while (i + 1) < self.len() {
+			if self[i] == self[i + 1] {
+				self.0.remove(i + 1);
+			} else {
+				i += 1;
+			}
+		}
+	}
+
 	/// Inserts an element, if no equal item exist in the set.
 	///
 	/// Returns an error if insertion would exceed the bounded vec's max size.
@@ -94,8 +108,8 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 
 	/// Inserts a new element or updates the value of an existing one.
 	///
-	/// Returns an error if the maximum size of the bounded vec would be exceeded
-	/// upon insertion.
+	/// Returns an error if the maximum size of the bounded vec would be
+	/// exceeded upon insertion.
 	///
 	/// Returns the old value if existing or None if the value did not exist
 	/// before.
@@ -276,12 +290,6 @@ impl<T: Ord + Clone, S: Get<u32>> Index<RangeFull> for OrderedSet<T, S> {
 	}
 }
 
-impl<T: Ord + Clone, S: Get<u32>> IndexMut<usize> for OrderedSet<T, S> {
-	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-		&mut self.0[index]
-	}
-}
-
 impl<T: Ord + Clone, S: Get<u32>> IntoIterator for OrderedSet<T, S> {
 	type Item = T;
 	type IntoIter = sp_std::vec::IntoIter<Self::Item>;
@@ -294,18 +302,6 @@ impl<T: Ord + Clone, S: Get<u32>> IntoIterator for OrderedSet<T, S> {
 impl<T: Ord + Clone, S: Get<u32>> From<OrderedSet<T, S>> for BoundedVec<T, S> {
 	fn from(s: OrderedSet<T, S>) -> Self {
 		s.0
-	}
-}
-
-impl<T: Ord + Clone, S: Get<u32>> IndexMut<Range<usize>> for OrderedSet<T, S> {
-	fn index_mut(&mut self, range: Range<usize>) -> &mut Self::Output {
-		&mut self.0[range]
-	}
-}
-
-impl<T: Ord + Clone, S: Get<u32>> IndexMut<RangeFull> for OrderedSet<T, S> {
-	fn index_mut(&mut self, range: RangeFull) -> &mut Self::Output {
-		&mut self.0[range]
 	}
 }
 

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -57,7 +57,7 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 
 	/// Inserts an element, if no equal item exist in the set.
 	///
-	/// Throws if insertion would exceed the bounded vec's max size.
+	/// Returns an error if insertion would exceed the bounded vec's max size.
 	///
 	/// Returns true if the item is unique in the set, otherwise returns false.
 	pub fn try_insert(&mut self, value: T) -> Result<bool, ()> {
@@ -73,8 +73,8 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 	/// Attempts to replace the last element of the set with the provided value.
 	/// Assumes the set to have reached its bounded size.
 	///
-	/// Throws with `false` if the value already exists in the set.
-	/// Throws with `true` if the value has the least order in the set, i.e.,
+	/// Returns `Err(false)` if the value already exists in the set.
+	/// Returns `Err(true)` if the value has the least order in the set, i.e.,
 	/// it would be appended (inserted at i == length).
 	///
 	/// Returns the replaced element upon success.
@@ -94,7 +94,7 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 
 	/// Inserts a new element or updates the value of an existing one.
 	///
-	/// Throws if the maximum size of the bounded vec would be exceeded
+	/// Returns an error if the maximum size of the bounded vec would be exceeded
 	/// upon insertion.
 	///
 	/// Returns the old value if existing or None if the value did not exist

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -183,7 +183,8 @@ where
 			owner: delegator,
 			amount: B::zero(),
 		}) {
-			self.delegators[i].amount = self.delegators[i].amount.saturating_add(more);
+			self.delegators
+				.mutate(|vec| vec[i].amount = vec[i].amount.saturating_add(more));
 			self.total = self.total.saturating_add(more);
 			self.delegators.sort_greatest_to_lowest()
 		}
@@ -194,7 +195,8 @@ where
 			owner: delegator,
 			amount: B::zero(),
 		}) {
-			self.delegators[i].amount = self.delegators[i].amount.saturating_sub(less);
+			self.delegators
+				.mutate(|vec| vec[i].amount = vec[i].amount.saturating_sub(less));
 			self.total = self.total.saturating_sub(less);
 			self.delegators.sort_greatest_to_lowest()
 		}
@@ -267,7 +269,8 @@ where
 			owner: collator,
 			amount: Balance::zero(),
 		}) {
-			self.delegations[i].amount = self.delegations[i].amount.saturating_add(more);
+			self.delegations
+				.mutate(|vec| vec[i].amount = vec[i].amount.saturating_add(more));
 			self.total = self.total.saturating_add(more);
 			self.delegations.sort_greatest_to_lowest();
 			Some(self.delegations[i].amount)
@@ -284,7 +287,8 @@ where
 			amount: Balance::zero(),
 		}) {
 			if self.delegations[i].amount > less {
-				self.delegations[i].amount = self.delegations[i].amount.saturating_sub(less);
+				self.delegations
+					.mutate(|vec| vec[i].amount = vec[i].amount.saturating_sub(less));
 				self.total = self.total.saturating_sub(less);
 				self.delegations.sort_greatest_to_lowest();
 				Some(Some(self.delegations[i].amount))


### PR DESCRIPTION
in preparation of KILTprotocol/mashnet-node/pull/244

* don't store the selected candidates in a separate list
* `select_top_candidates` -> `update_total_stake`
* ensure that the set is always sorted (no mutation without resorting)

storage migration will be handled in KILTprotocol/mashnet-node/pull/244

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
