### PR TITLE
refactor(staking): Collator -> candidate

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -201,7 +201,7 @@ pub mod pallet {
 		migrations::StakingStorageVersion,
 		set::OrderedSet,
 		types::{
-			BalanceOf, Candidate, CollatorOf, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf,
+			BalanceOf, Candidate, CandidateOf, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf,
 			TotalStake,
 		},
 	};
@@ -2177,7 +2177,7 @@ pub mod pallet {
 		fn do_update_delegator(
 			stake: Stake<T::AccountId, BalanceOf<T>>,
 			mut state: Candidate<T::AccountId, BalanceOf<T>, T::MaxDelegatorsPerCollator>,
-		) -> Result<CollatorOf<T, T::MaxDelegatorsPerCollator>, DispatchError> {
+		) -> Result<CandidateOf<T, T::MaxDelegatorsPerCollator>, DispatchError> {
 			// attempt to replace the last element of the set
 			let stake_to_remove = state
 				.delegators
@@ -2332,7 +2332,7 @@ pub mod pallet {
 		/// # </weight>
 		fn remove_candidate(
 			collator: &T::AccountId,
-			state: CollatorOf<T, T::MaxDelegatorsPerCollator>,
+			state: CandidateOf<T, T::MaxDelegatorsPerCollator>,
 		) -> DispatchResult {
 			// iterate over delegators
 			for stake in state.delegators.into_iter() {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -201,8 +201,8 @@ pub mod pallet {
 		migrations::StakingStorageVersion,
 		set::OrderedSet,
 		types::{
-			BalanceOf, Candidate, CandidateOf, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf,
-			TotalStake,
+			BalanceOf, Candidate, CandidateOf, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake,
+			StakeOf, TotalStake,
 		},
 	};
 	use sp_std::{convert::TryInto, fmt::Debug};

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -201,7 +201,7 @@ pub mod pallet {
 		migrations::StakingStorageVersion,
 		set::OrderedSet,
 		types::{
-			BalanceOf, Collator, CollatorOf, CollatorStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf,
+			BalanceOf, Candidate, CollatorOf, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf,
 			TotalStake,
 		},
 	};
@@ -572,25 +572,26 @@ pub mod pallet {
 		OptionQuery,
 	>;
 
-	/// Collator candidates staking information.
+	/// The staking information for a candidate.
 	///
-	/// It maps from an account to its collator details.
+	/// It maps from an account to its information.
 	#[pallet::storage]
-	#[pallet::getter(fn collator_state)]
-	pub(crate) type CollatorState<T: Config> = StorageMap<
+	#[pallet::getter(fn candidate_state)]
+	pub(crate) type CandidateState<T: Config> = StorageMap<
 		_,
 		Twox64Concat,
 		T::AccountId,
-		Collator<T::AccountId, BalanceOf<T>, T::MaxDelegatorsPerCollator>,
+		Candidate<T::AccountId, BalanceOf<T>, T::MaxDelegatorsPerCollator>,
 		OptionQuery,
 	>;
 
 	/// Total funds locked to back the currently selected collators.
+	/// The sum of all the delegator stake and collator stake.
 	///
 	/// Note: There are more funds locked by this pallet, since the backing for
 	/// candidates (non collating) is not included in [TotalCollatorStake].
 	#[pallet::storage]
-	#[pallet::getter(fn total)]
+	#[pallet::getter(fn total_collator_stake)]
 	pub(crate) type TotalCollatorStake<T: Config> = StorageValue<_, TotalStake<BalanceOf<T>>, ValueQuery>;
 
 	/// The set of collator candidates, each with their total backing stake.
@@ -910,7 +911,7 @@ pub mod pallet {
 				pool.mutate(|vec| {
 					for mut candidate in vec[..].iter_mut() {
 						// state should always exist but let's be safe
-						if let Some(mut state) = <CollatorState<T>>::get(&candidate.owner) {
+						if let Some(mut state) = <CandidateState<T>>::get(&candidate.owner) {
 							if state.stake > new {
 								// safe because we ensure stake > new
 								let delta = state.stake - new;
@@ -919,7 +920,7 @@ pub mod pallet {
 
 								// immediately free delta by setting lock from old to new
 								T::Currency::set_lock(STAKING_ID, &candidate.owner, new, WithdrawReasons::all());
-								<CollatorState<T>>::insert(&candidate.owner, state);
+								<CandidateState<T>>::insert(&candidate.owner, state);
 							}
 						}
 					}
@@ -972,7 +973,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
 			let collator = T::Lookup::lookup(collator)?;
-			let state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			let total_amount = state.total;
 
 			let mut candidates = <CandidatePool<T>>::get();
@@ -1073,8 +1074,8 @@ pub mod pallet {
 
 			Self::increase_lock(&acc, stake, BalanceOf::<T>::zero())?;
 
-			let candidate = Collator::new(acc.clone(), stake);
-			<CollatorState<T>>::insert(&acc, candidate);
+			let candidate = Candidate::new(acc.clone(), stake);
+			<CandidateState<T>>::insert(&acc, candidate);
 			<CandidatePool<T>>::put(candidates);
 
 			// update candidates for next round
@@ -1131,7 +1132,7 @@ pub mod pallet {
 		))]
 		pub fn init_leave_candidates(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let collator = ensure_signed(origin)?;
-			let mut state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(!state.is_leaving(), Error::<T>::AlreadyLeaving);
 			let mut candidates = <CandidatePool<T>>::get();
 			ensure!(
@@ -1151,7 +1152,7 @@ pub mod pallet {
 			{
 				<CandidatePool<T>>::put(candidates);
 			}
-			<CollatorState<T>>::insert(&collator, state);
+			<CandidateState<T>>::insert(&collator, state);
 
 			// update candidates for next round
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
@@ -1197,7 +1198,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			ensure_signed(origin)?;
 			let collator = T::Lookup::lookup(collator)?;
-			let state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(state.is_leaving(), Error::<T>::NotLeaving);
 			ensure!(state.can_exit(<Round<T>>::get().current), Error::<T>::CannotLeaveYet);
 
@@ -1243,7 +1244,7 @@ pub mod pallet {
 		))]
 		pub fn cancel_leave_candidates(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let acc = ensure_signed(origin)?;
-			let mut state = <CollatorState<T>>::get(&acc).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&acc).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(state.is_leaving(), Error::<T>::NotLeaving);
 
 			// add candidate back to pool
@@ -1270,7 +1271,7 @@ pub mod pallet {
 			state.revert_leaving();
 
 			// update candidates for next round
-			<CollatorState<T>>::insert(&acc, state);
+			<CandidateState<T>>::insert(&acc, state);
 			<CandidatePool<T>>::put(candidates);
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
 
@@ -1314,7 +1315,7 @@ pub mod pallet {
 			let collator = ensure_signed(origin)?;
 
 			ensure!(!more.is_zero(), Error::<T>::ValStakeZero);
-			let mut state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(!state.is_leaving(), Error::<T>::CannotStakeIfLeaving);
 
 			let before = state.stake;
@@ -1330,7 +1331,7 @@ pub mod pallet {
 			if state.is_active() {
 				Self::update(collator.clone(), state.total)?;
 			}
-			<CollatorState<T>>::insert(&collator, state);
+			<CandidateState<T>>::insert(&collator, state);
 
 			// update candidates for next round
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
@@ -1377,7 +1378,7 @@ pub mod pallet {
 			let collator = ensure_signed(origin)?;
 			ensure!(!less.is_zero(), Error::<T>::ValStakeZero);
 
-			let mut state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(!state.is_leaving(), Error::<T>::CannotStakeIfLeaving);
 			let before = state.stake;
 			let after = state.stake_less(less).ok_or(Error::<T>::Underflow)?;
@@ -1392,7 +1393,7 @@ pub mod pallet {
 			if state.is_active() {
 				Self::update(collator.clone(), state.total)?;
 			}
-			<CollatorState<T>>::insert(&collator, state);
+			<CandidateState<T>>::insert(&collator, state);
 
 			// update candidates for next round
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
@@ -1461,7 +1462,7 @@ pub mod pallet {
 			let delegation_counter = Self::get_delegation_counter(&acc)?;
 
 			// prepare update of collator state
-			let mut state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			let num_delegations_pre_insertion: u32 = state.delegators.len().saturated_into();
 
 			ensure!(!state.is_leaving(), Error::<T>::CannotDelegateIfLeaving);
@@ -1502,7 +1503,7 @@ pub mod pallet {
 			}
 
 			// update states
-			<CollatorState<T>>::insert(&collator, state);
+			<CandidateState<T>>::insert(&collator, state);
 			<DelegatorState<T>>::insert(&acc, delegator_state);
 			<LastDelegation<T>>::insert(&acc, delegation_counter);
 
@@ -1586,7 +1587,7 @@ pub mod pallet {
 			let delegation_counter = Self::get_delegation_counter(&acc)?;
 
 			// prepare new collator state
-			let mut state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 			let num_delegations_pre_insertion: u32 = state.delegators.len().saturated_into();
 			ensure!(!state.is_leaving(), Error::<T>::CannotDelegateIfLeaving);
 
@@ -1630,7 +1631,7 @@ pub mod pallet {
 			}
 
 			// Update states
-			<CollatorState<T>>::insert(&collator, state);
+			<CandidateState<T>>::insert(&collator, state);
 			<DelegatorState<T>>::insert(&acc, delegator);
 			<LastDelegation<T>>::insert(&acc, delegation_counter);
 
@@ -1781,7 +1782,7 @@ pub mod pallet {
 
 			let candidate = T::Lookup::lookup(candidate)?;
 			let mut delegations = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorNotFound)?;
-			let mut collator = <CollatorState<T>>::get(&candidate).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut collator = <CandidateState<T>>::get(&candidate).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(!collator.is_leaving(), Error::<T>::CannotDelegateIfLeaving);
 			let delegator_total = delegations
 				.inc_delegation(candidate.clone(), more)
@@ -1796,7 +1797,7 @@ pub mod pallet {
 			if collator.is_active() {
 				Self::update(candidate.clone(), collator.total)?;
 			}
-			<CollatorState<T>>::insert(&candidate, collator);
+			<CandidateState<T>>::insert(&candidate, collator);
 			<DelegatorState<T>>::insert(&delegator, delegations);
 
 			// update candidates for next round
@@ -1853,7 +1854,7 @@ pub mod pallet {
 
 			let candidate = T::Lookup::lookup(candidate)?;
 			let mut delegations = <DelegatorState<T>>::get(&delegator).ok_or(Error::<T>::DelegatorNotFound)?;
-			let mut collator = <CollatorState<T>>::get(&candidate).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut collator = <CandidateState<T>>::get(&candidate).ok_or(Error::<T>::CandidateNotFound)?;
 			ensure!(!collator.is_leaving(), Error::<T>::CannotDelegateIfLeaving);
 			let remaining = delegations
 				.dec_delegation(candidate.clone(), less)
@@ -1874,7 +1875,7 @@ pub mod pallet {
 			if collator.is_active() {
 				Self::update(candidate.clone(), collator.total)?;
 			}
-			<CollatorState<T>>::insert(&candidate, collator);
+			<CandidateState<T>>::insert(&candidate, collator);
 			<DelegatorState<T>>::insert(&delegator, delegations);
 
 			// update candidates for next round
@@ -1931,8 +1932,8 @@ pub mod pallet {
 		/// - Reads: CollatorState
 		/// # </weight>
 		pub fn is_active_candidate(acc: &T::AccountId) -> Option<bool> {
-			if let Some(state) = <CollatorState<T>>::get(acc) {
-				Some(state.state == CollatorStatus::Active)
+			if let Some(state) = <CandidateState<T>>::get(acc) {
+				Some(state.status == CandidateStatus::Active)
 			} else {
 				None
 			}
@@ -2018,7 +2019,7 @@ pub mod pallet {
 		/// - Writes: Unstaking, Total, CollatorState
 		/// # </weight>
 		fn delegator_leaves_collator(delegator: T::AccountId, collator: T::AccountId) -> DispatchResult {
-			let mut state = <CollatorState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
+			let mut state = <CandidateState<T>>::get(&collator).ok_or(Error::<T>::CandidateNotFound)?;
 
 			let delegator_stake = state
 				.delegators
@@ -2039,7 +2040,7 @@ pub mod pallet {
 				Self::update(collator.clone(), state.total)?;
 			}
 			let new_total = state.total;
-			<CollatorState<T>>::insert(&collator, state);
+			<CandidateState<T>>::insert(&collator, state);
 
 			Self::deposit_event(Event::DelegatorLeftCollator(
 				delegator,
@@ -2096,7 +2097,7 @@ pub mod pallet {
 			// Snapshot exposure for round for weighting reward distribution
 			for account in collators.iter() {
 				let state =
-					<CollatorState<T>>::get(&account).expect("all members of CandidatePool must be candidates q.e.d");
+					<CandidateState<T>>::get(&account).expect("all members of CandidatePool must be candidates q.e.d");
 				num_of_delegators = num_of_delegators.saturating_add(state.delegators.len().saturated_into::<u32>());
 
 				// sum up total stake and amount of collators, delegators
@@ -2175,7 +2176,7 @@ pub mod pallet {
 		/// # </weight>
 		fn do_update_delegator(
 			stake: Stake<T::AccountId, BalanceOf<T>>,
-			mut state: Collator<T::AccountId, BalanceOf<T>, T::MaxDelegatorsPerCollator>,
+			mut state: Candidate<T::AccountId, BalanceOf<T>, T::MaxDelegatorsPerCollator>,
 		) -> Result<CollatorOf<T, T::MaxDelegatorsPerCollator>, DispatchError> {
 			// attempt to replace the last element of the set
 			let stake_to_remove = state
@@ -2365,7 +2366,7 @@ pub mod pallet {
 				// FIXME: Does not prevent the collator from being able to author a block in this (or potentially the next) session. See https://github.com/paritytech/substrate/issues/8004
 				.map(pallet_session::Pallet::<T>::disable_index);
 
-			<CollatorState<T>>::remove(&collator);
+			<CandidateState<T>>::remove(&collator);
 			Ok(())
 		}
 
@@ -2564,7 +2565,7 @@ pub mod pallet {
 			);
 			// should always include state except if the collator has been forcedly removed
 			// via `force_remove_candidate` in the current or previous round
-			if let Some(state) = <CollatorState<T>>::get(author.clone()) {
+			if let Some(state) = <CandidateState<T>>::get(author.clone()) {
 				let total_issuance = T::Currency::total_issuance();
 				let TotalStake {
 					collators: total_collators,

--- a/pallets/parachain-staking/src/migrations/v4.rs
+++ b/pallets/parachain-staking/src/migrations/v4.rs
@@ -18,7 +18,7 @@
 
 use crate::{
 	migrations::StakingStorageVersion,
-	types::{CollatorOf, Delegator},
+	types::{CandidateOf, Delegator},
 	CandidatePool, CandidateState, Config, DelegatorState, StorageVersion,
 };
 use frame_support::{dispatch::Weight, traits::Get};
@@ -37,7 +37,7 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	let mut n = 1u64;
 
 	// for each candidate: sort delegators from greatest to lowest
-	CandidateState::<T>::translate_values(|mut state: CollatorOf<T, T::MaxDelegatorsPerCollator>| {
+	CandidateState::<T>::translate_values(|mut state: CandidateOf<T, T::MaxDelegatorsPerCollator>| {
 		state.delegators.sort_greatest_to_lowest();
 		n = n.saturating_add(1u64);
 		Some(state)

--- a/pallets/parachain-staking/src/migrations/v4.rs
+++ b/pallets/parachain-staking/src/migrations/v4.rs
@@ -19,7 +19,7 @@
 use crate::{
 	migrations::StakingStorageVersion,
 	types::{CollatorOf, Delegator},
-	CandidatePool, CollatorState, Config, DelegatorState, StorageVersion,
+	CandidatePool, CandidateState, Config, DelegatorState, StorageVersion,
 };
 use frame_support::{dispatch::Weight, traits::Get};
 
@@ -37,7 +37,7 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	let mut n = 1u64;
 
 	// for each candidate: sort delegators from greatest to lowest
-	CollatorState::<T>::translate_values(|mut state: CollatorOf<T, T::MaxDelegatorsPerCollator>| {
+	CandidateState::<T>::translate_values(|mut state: CollatorOf<T, T::MaxDelegatorsPerCollator>| {
 		state.delegators.sort_greatest_to_lowest();
 		n = n.saturating_add(1u64);
 		Some(state)

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -36,7 +36,9 @@ use crate::{
 		ExtBuilder, Origin, Session, StakePallet, System, Test, BLOCKS_PER_ROUND, DECIMALS,
 	},
 	set::OrderedSet,
-	types::{BalanceOf, Candidate, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf, TotalStake},
+	types::{
+		BalanceOf, Candidate, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf, TotalStake,
+	},
 	Config, Error, Event, InflationInfo, RewardRate, StakingInfo, STAKING_ID,
 };
 

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -36,7 +36,7 @@ use crate::{
 		ExtBuilder, Origin, Session, StakePallet, System, Test, BLOCKS_PER_ROUND, DECIMALS,
 	},
 	set::OrderedSet,
-	types::{BalanceOf, Collator, CollatorStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf, TotalStake},
+	types::{BalanceOf, Candidate, CandidateStatus, DelegationCounter, Delegator, RoundInfo, Stake, StakeOf, TotalStake},
 	Config, Error, Event, InflationInfo, RewardRate, StakingInfo, STAKING_ID,
 };
 
@@ -96,7 +96,7 @@ fn genesis() {
 
 			// Collators
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: 700,
 					delegators: 400
@@ -115,9 +115,9 @@ fn genesis() {
 			assert_eq!(Balances::free_balance(&1), 1000);
 			assert!(StakePallet::is_active_candidate(&1).is_some());
 			assert_eq!(
-				StakePallet::collator_state(&1),
+				StakePallet::candidate_state(&1),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 1,
 						stake: 500,
 						delegators: OrderedSet::from_sorted_set(
@@ -129,7 +129,7 @@ fn genesis() {
 							.unwrap()
 						),
 						total: 700,
-						state: CollatorStatus::Active,
+						status: CandidateStatus::Active,
 					}
 				)
 			);
@@ -138,9 +138,9 @@ fn genesis() {
 			assert_eq!(Balances::free_balance(&2), 300);
 			assert!(StakePallet::is_active_candidate(&2).is_some());
 			assert_eq!(
-				StakePallet::collator_state(&2),
+				StakePallet::candidate_state(&2),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 2,
 						stake: 200,
 						delegators: OrderedSet::from_sorted_set(
@@ -152,13 +152,13 @@ fn genesis() {
 							.unwrap()
 						),
 						total: 400,
-						state: CollatorStatus::Active,
+						status: CandidateStatus::Active,
 					}
 				)
 			);
 			// Delegators
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: 700,
 					delegators: 400,
@@ -211,7 +211,7 @@ fn genesis() {
 
 			// Collators
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: 40,
 					delegators: 50
@@ -275,7 +275,7 @@ fn join_collator_candidates() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: 700,
 					delegators: 400
@@ -366,8 +366,8 @@ fn collator_exit_executes_after_delay() {
 				last_event(),
 				MetaEvent::StakePallet(Event::CollatorScheduledExit(2, 2, 4))
 			);
-			let info = StakePallet::collator_state(&2).unwrap();
-			assert_eq!(info.state, CollatorStatus::Leaving(4));
+			let info = StakePallet::candidate_state(&2).unwrap();
+			assert_eq!(info.status, CandidateStatus::Leaving(4));
 
 			roll_to(21, vec![]);
 			assert_ok!(StakePallet::execute_leave_candidates(Origin::signed(2), 2));
@@ -609,7 +609,7 @@ fn execute_leave_candidates_with_delay() {
 			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
 			roll_to(5, vec![]);
 			// should choose top MaxSelectedCandidates (5), in order
-			let mut old_stake = StakePallet::total();
+			let mut old_stake = StakePallet::total_collator_stake();
 			assert_eq!(
 				old_stake,
 				TotalStake {
@@ -628,7 +628,7 @@ fn execute_leave_candidates_with_delay() {
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(2)));
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![4, 3]);
 			for owner in vec![1, 2, 5, 6, 7, 8, 9, 10].iter() {
-				assert!(StakePallet::collator_state(owner)
+				assert!(StakePallet::candidate_state(owner)
 					.unwrap()
 					.can_exit(1 + <Test as Config>::ExitQueueDelay::get()));
 			}
@@ -636,11 +636,11 @@ fn execute_leave_candidates_with_delay() {
 				collators: 70,
 				delegators: 0,
 			};
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 			assert_eq!(
-				StakePallet::collator_state(1),
+				StakePallet::candidate_state(1),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 1,
 						stake: 10,
 						delegators: OrderedSet::from(
@@ -652,14 +652,14 @@ fn execute_leave_candidates_with_delay() {
 							.unwrap()
 						),
 						total: 240,
-						state: CollatorStatus::Leaving(3)
+						status: CandidateStatus::Leaving(3)
 					}
 				)
 			);
 			assert_eq!(
-				StakePallet::collator_state(2),
+				StakePallet::candidate_state(2),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 2,
 						stake: 20,
 						delegators: OrderedSet::from(
@@ -671,20 +671,20 @@ fn execute_leave_candidates_with_delay() {
 							.unwrap()
 						),
 						total: 290,
-						state: CollatorStatus::Leaving(3)
+						status: CandidateStatus::Leaving(3)
 					}
 				)
 			);
 			for collator in 5u64..=10u64 {
 				assert_eq!(
-					StakePallet::collator_state(collator),
+					StakePallet::candidate_state(collator),
 					Some(
-						Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+						Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 							id: collator,
 							stake: collator as u128 * 10u128,
 							delegators: OrderedSet::from(BoundedVec::default()),
 							total: collator as u128 * 10u128,
-							state: CollatorStatus::Leaving(3)
+							status: CandidateStatus::Leaving(3)
 						}
 					)
 				);
@@ -742,10 +742,10 @@ fn execute_leave_candidates_with_delay() {
 
 			// exits cannot be executed yet but in the next round
 			roll_to(10, vec![]);
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![4, 3]);
 			for owner in vec![1, 2, 5, 6, 7, 8, 9, 10].iter() {
-				assert!(StakePallet::collator_state(owner)
+				assert!(StakePallet::candidate_state(owner)
 					.unwrap()
 					.can_exit(1 + <Test as Config>::ExitQueueDelay::get()));
 				assert_noop!(
@@ -753,11 +753,11 @@ fn execute_leave_candidates_with_delay() {
 					Error::<Test>::CannotLeaveYet
 				);
 			}
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 			assert_eq!(
-				StakePallet::collator_state(1),
+				StakePallet::candidate_state(1),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 1,
 						stake: 10,
 						delegators: OrderedSet::from(
@@ -769,14 +769,14 @@ fn execute_leave_candidates_with_delay() {
 							.unwrap()
 						),
 						total: 240,
-						state: CollatorStatus::Leaving(3)
+						status: CandidateStatus::Leaving(3)
 					}
 				)
 			);
 			assert_eq!(
-				StakePallet::collator_state(2),
+				StakePallet::candidate_state(2),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 2,
 						stake: 20,
 						delegators: OrderedSet::from(
@@ -788,20 +788,20 @@ fn execute_leave_candidates_with_delay() {
 							.unwrap()
 						),
 						total: 290,
-						state: CollatorStatus::Leaving(3)
+						status: CandidateStatus::Leaving(3)
 					}
 				)
 			);
 			for collator in 5u64..=10u64 {
 				assert_eq!(
-					StakePallet::collator_state(collator),
+					StakePallet::candidate_state(collator),
 					Some(
-						Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+						Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 							id: collator,
 							stake: collator as u128 * 10u128,
 							delegators: OrderedSet::from(BoundedVec::default()),
 							total: collator as u128 * 10u128,
-							state: CollatorStatus::Leaving(3)
+							status: CandidateStatus::Leaving(3)
 						}
 					)
 				);
@@ -859,18 +859,18 @@ fn execute_leave_candidates_with_delay() {
 
 			// execute first five exits are executed
 			roll_to(15, vec![]);
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![4, 3]);
 			for collator in vec![1u64, 2u64, 5u64, 6u64, 7u64].iter() {
 				assert_ok!(StakePallet::execute_leave_candidates(
 					Origin::signed(*collator),
 					*collator
 				));
-				assert!(StakePallet::collator_state(&collator).is_none());
+				assert!(StakePallet::candidate_state(&collator).is_none());
 				assert!(!StakePallet::is_active_candidate(collator).is_some());
 				assert_eq!(StakePallet::unstaking(collator).len(), 1);
 			}
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 			for delegator in 11u64..=14u64 {
 				assert!(!StakePallet::is_delegator(&delegator));
 				assert_eq!(StakePallet::unstaking(delegator).len(), 1);
@@ -883,7 +883,7 @@ fn execute_leave_candidates_with_delay() {
 					Origin::signed(collator),
 					collator
 				));
-				assert!(StakePallet::collator_state(&collator).is_none());
+				assert!(StakePallet::candidate_state(&collator).is_none());
 				assert!(!StakePallet::is_active_candidate(&collator).is_some());
 				assert_eq!(StakePallet::unstaking(collator).len(), 1);
 			}
@@ -989,7 +989,7 @@ fn multiple_delegations() {
 			assert_ok!(StakePallet::join_delegators(Origin::signed(11), 2, 11));
 			assert!(StakePallet::delegator_state(9).is_none());
 			assert_eq!(StakePallet::unstaking(9).get(&23), Some(&10u128));
-			assert!(!StakePallet::collator_state(2)
+			assert!(!StakePallet::candidate_state(2)
 				.unwrap()
 				.delegators
 				.contains(&StakeOf::<Test> { owner: 9, amount: 10 }));
@@ -1109,27 +1109,27 @@ fn should_update_total_stake() {
 		.set_blocks_per_round(5)
 		.build()
 		.execute_with(|| {
-			let mut old_stake = StakePallet::total();
+			let mut old_stake = StakePallet::total_collator_stake();
 			assert_ok!(StakePallet::candidate_stake_more(Origin::signed(1), 50));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: old_stake.collators + 50,
 					..old_stake
 				}
 			);
 
-			old_stake = StakePallet::total();
+			old_stake = StakePallet::total_collator_stake();
 			assert_ok!(StakePallet::candidate_stake_less(Origin::signed(1), 50));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: old_stake.collators - 50,
 					..old_stake
 				}
 			);
 
-			old_stake = StakePallet::total();
+			old_stake = StakePallet::total_collator_stake();
 			assert_ok!(StakePallet::delegator_stake_more(Origin::signed(7), 1, 50));
 			assert_noop!(
 				StakePallet::delegator_stake_more(Origin::signed(7), 1, 0),
@@ -1140,59 +1140,59 @@ fn should_update_total_stake() {
 				Error::<Test>::ValStakeZero
 			);
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					delegators: old_stake.delegators + 50,
 					..old_stake
 				}
 			);
 
-			old_stake = StakePallet::total();
+			old_stake = StakePallet::total_collator_stake();
 			assert_ok!(StakePallet::delegator_stake_less(Origin::signed(7), 1, 50));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					delegators: old_stake.delegators - 50,
 					..old_stake
 				}
 			);
 
-			old_stake = StakePallet::total();
+			old_stake = StakePallet::total_collator_stake();
 			assert_ok!(StakePallet::join_delegators(Origin::signed(11), 1, 200));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					delegators: old_stake.delegators + 200,
 					..old_stake
 				}
 			);
 
-			old_stake = StakePallet::total();
+			old_stake = StakePallet::total_collator_stake();
 			assert_ok!(StakePallet::delegate_another_candidate(Origin::signed(11), 2, 150));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					delegators: old_stake.delegators + 150,
 					..old_stake
 				}
 			);
 
-			old_stake = StakePallet::total();
+			old_stake = StakePallet::total_collator_stake();
 			assert_eq!(StakePallet::delegator_state(11).unwrap().total, 350);
 			assert_ok!(StakePallet::leave_delegators(Origin::signed(11)));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					delegators: old_stake.delegators - 350,
 					..old_stake
 				}
 			);
 
-			let old_stake = StakePallet::total();
+			let old_stake = StakePallet::total_collator_stake();
 			assert_eq!(StakePallet::delegator_state(8).unwrap().total, 10);
 			assert_ok!(StakePallet::revoke_delegation(Origin::signed(8), 2));
 			assert_eq!(
-				StakePallet::total(),
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					delegators: old_stake.delegators - 10,
 					..old_stake
@@ -1201,13 +1201,13 @@ fn should_update_total_stake() {
 
 			// should immediately affect total stake because collator can't be chosen in
 			// active set from now on, thus delegated stake is reduced
-			let old_stake = StakePallet::total();
-			assert_eq!(StakePallet::collator_state(2).unwrap().total, 30);
-			assert_eq!(StakePallet::collator_state(2).unwrap().stake, 20);
+			let old_stake = StakePallet::total_collator_stake();
+			assert_eq!(StakePallet::candidate_state(2).unwrap().total, 30);
+			assert_eq!(StakePallet::candidate_state(2).unwrap().stake, 20);
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![2, 1]);
 			assert_eq!(
-				StakePallet::collator_state(2).unwrap().stake,
-				StakePallet::collator_state(3).unwrap().stake
+				StakePallet::candidate_state(2).unwrap().stake,
+				StakePallet::candidate_state(3).unwrap().stake
 			);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(2)));
 			let old_stake = TotalStake {
@@ -1217,13 +1217,13 @@ fn should_update_total_stake() {
 				collators: old_stake.collators,
 			};
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 3]);
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 
 			// shouldn't change total stake when 2 leaves
 			roll_to(10, vec![]);
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 			assert_ok!(StakePallet::execute_leave_candidates(Origin::signed(2), 2));
-			assert_eq!(StakePallet::total(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), old_stake);
 		})
 }
 
@@ -1267,7 +1267,7 @@ fn collators_bond() {
 				BalancesError::<Test>::InsufficientBalance
 			);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(1)));
-			assert!(StakePallet::collator_state(1)
+			assert!(StakePallet::candidate_state(1)
 				.unwrap()
 				.can_exit(<Test as Config>::ExitQueueDelay::get()));
 
@@ -1393,7 +1393,7 @@ fn delegators_bond() {
 			roll_to(9, vec![]);
 			assert_eq!(Balances::usable_balance(&6), 80);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(1)));
-			assert!(StakePallet::collator_state(1)
+			assert!(StakePallet::candidate_state(1)
 				.unwrap()
 				.can_exit(1 + <Test as Config>::ExitQueueDelay::get()));
 
@@ -1835,7 +1835,7 @@ fn should_not_reward_delegators_below_min_stake() {
 		.build()
 		.execute_with(|| {
 			// impossible but lets assume it happened
-			let mut state = StakePallet::collator_state(&1).expect("CollatorState cannot be missing");
+			let mut state = StakePallet::candidate_state(&1).expect("CollatorState cannot be missing");
 			let delegator_stake_below_min = <Test as Config>::MinDelegatorStake::get() - 1;
 			state.stake += delegator_stake_below_min;
 			state.total += delegator_stake_below_min;
@@ -1844,7 +1844,7 @@ fn should_not_reward_delegators_below_min_stake() {
 				amount: delegator_stake_below_min,
 			};
 			assert_eq!(state.delegators.try_insert(impossible_bond), Ok(true));
-			<crate::CollatorState<Test>>::insert(&1u64, state);
+			<crate::CandidateState<Test>>::insert(&1u64, state);
 
 			let authors: Vec<Option<AccountId>> = vec![Some(1u64), Some(1u64), Some(1u64), Some(1u64)];
 			assert_eq!(Balances::usable_balance(&1), Balance::zero());
@@ -2495,12 +2495,12 @@ fn candidate_leaves() {
 				Error::<Test>::AlreadyLeaving
 			);
 			assert_eq!(
-				StakePallet::collator_state(1).unwrap().state,
-				CollatorStatus::Leaving(2)
+				StakePallet::candidate_state(1).unwrap().status,
+				CandidateStatus::Leaving(2)
 			);
-			assert!(StakePallet::collator_state(1).unwrap().can_exit(2));
-			assert!(!StakePallet::collator_state(1).unwrap().can_exit(1));
-			assert!(StakePallet::collator_state(1).unwrap().can_exit(3));
+			assert!(StakePallet::candidate_state(1).unwrap().can_exit(2));
+			assert!(!StakePallet::candidate_state(1).unwrap().can_exit(1));
+			assert!(StakePallet::candidate_state(1).unwrap().can_exit(3));
 
 			// next rounds starts, cannot leave yet
 			roll_to(5, vec![]);
@@ -2531,8 +2531,8 @@ fn candidate_leaves() {
 				StakePallet::candidate_pool(),
 				OrderedSet::from(stake.try_into().unwrap())
 			);
-			let state = StakePallet::collator_state(1).unwrap();
-			assert_eq!(state.state, CollatorStatus::Active);
+			let state = StakePallet::candidate_state(1).unwrap();
+			assert_eq!(state.status, CandidateStatus::Active);
 			assert_eq!(state.delegators.len(), 2);
 			assert_eq!(state.total, 210);
 			assert_eq!(
@@ -2721,42 +2721,42 @@ fn decrease_max_candidate_stake_by() {
 				)
 			);
 			assert_eq!(
-				StakePallet::collator_state(1),
+				StakePallet::candidate_state(1),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 1,
 						stake: 50,
 						delegators: OrderedSet::from(BoundedVec::default()),
 						total: 50,
-						state: CollatorStatus::Active
+						status: CandidateStatus::Active
 					}
 				)
 			);
 			assert_eq!(
-				StakePallet::collator_state(2),
+				StakePallet::candidate_state(2),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 2,
 						stake: 50,
 						delegators: OrderedSet::from(
 							vec![StakeOf::<Test> { owner: 4, amount: 10 }].try_into().unwrap()
 						),
 						total: 60,
-						state: CollatorStatus::Active
+						status: CandidateStatus::Active
 					}
 				)
 			);
 			assert_eq!(
-				StakePallet::collator_state(3),
+				StakePallet::candidate_state(3),
 				Some(
-					Collator::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
+					Candidate::<AccountId, Balance, <Test as Config>::MaxDelegatorsPerCollator> {
 						id: 3,
 						stake: 40,
 						delegators: OrderedSet::from(
 							vec![StakeOf::<Test> { owner: 5, amount: 20 }].try_into().unwrap()
 						),
 						total: 60,
-						state: CollatorStatus::Active
+						status: CandidateStatus::Active
 					}
 				)
 			);
@@ -2862,7 +2862,7 @@ fn force_remove_candidate() {
 			assert_eq!(last_event(), MetaEvent::StakePallet(Event::CollatorRemoved(1, 200)));
 			assert!(!StakePallet::candidate_pool().contains(&StakeOf::<Test> { owner: 1, amount: 100 }));
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![2, 3]);
-			assert!(StakePallet::collator_state(1).is_none());
+			assert!(StakePallet::candidate_state(1).is_none());
 			assert!(StakePallet::delegator_state(5).is_none());
 			assert_eq!(
 				StakePallet::delegator_state(4),
@@ -3099,7 +3099,7 @@ fn prioritize_delegators() {
 		.execute_with(|| {
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![2, 1]);
 			assert_eq!(
-				StakePallet::collator_state(2).unwrap().delegators,
+				StakePallet::candidate_state(2).unwrap().delegators,
 				OrderedSet::from_sorted_set(
 					vec![
 						StakeOf::<Test> { owner: 4, amount: 100 },
@@ -3112,7 +3112,7 @@ fn prioritize_delegators() {
 			);
 			assert_ok!(StakePallet::delegate_another_candidate(Origin::signed(5), 2, 110));
 			assert_eq!(
-				StakePallet::collator_state(2).unwrap().delegators,
+				StakePallet::candidate_state(2).unwrap().delegators,
 				OrderedSet::from_sorted_set(
 					vec![
 						StakeOf::<Test> { owner: 5, amount: 110 },
@@ -3139,7 +3139,7 @@ fn prioritize_delegators() {
 			// delegate_less
 			assert_ok!(StakePallet::delegator_stake_less(Origin::signed(5), 2, 10));
 			assert_eq!(
-				StakePallet::collator_state(2).unwrap().delegators,
+				StakePallet::candidate_state(2).unwrap().delegators,
 				OrderedSet::from_sorted_set(
 					vec![
 						StakeOf::<Test> { owner: 5, amount: 100 },
@@ -3166,7 +3166,7 @@ fn prioritize_delegators() {
 			// delegate_more
 			assert_ok!(StakePallet::delegator_stake_more(Origin::signed(6), 2, 10));
 			assert_eq!(
-				StakePallet::collator_state(2).unwrap().delegators,
+				StakePallet::candidate_state(2).unwrap().delegators,
 				OrderedSet::from_sorted_set(
 					vec![
 						StakeOf::<Test> { owner: 6, amount: 110 },
@@ -3180,7 +3180,7 @@ fn prioritize_delegators() {
 			);
 			assert_ok!(StakePallet::delegator_stake_more(Origin::signed(7), 2, 10));
 			assert_eq!(
-				StakePallet::collator_state(2).unwrap().delegators,
+				StakePallet::candidate_state(2).unwrap().delegators,
 				OrderedSet::from_sorted_set(
 					vec![
 						StakeOf::<Test> { owner: 6, amount: 110 },

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -367,5 +367,5 @@ pub struct DelegationCounter {
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
-pub type CollatorOf<T, S> = Candidate<AccountIdOf<T>, BalanceOf<T>, S>;
+pub type CandidateOf<T, S> = Candidate<AccountIdOf<T>, BalanceOf<T>, S>;
 pub type StakeOf<T> = Stake<AccountIdOf<T>, BalanceOf<T>>;

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -88,47 +88,47 @@ impl<AccountId: Ord, Balance: PartialEq + Ord> Ord for Stake<AccountId, Balance>
 
 /// The activity status of the collator.
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug)]
-pub enum CollatorStatus {
+pub enum CandidateStatus {
 	/// Committed to be online and producing valid blocks (not equivocating)
 	Active,
 	/// Staked until the inner round
 	Leaving(SessionIndex),
 }
 
-impl Default for CollatorStatus {
-	fn default() -> CollatorStatus {
-		CollatorStatus::Active
+impl Default for CandidateStatus {
+	fn default() -> CandidateStatus {
+		CandidateStatus::Active
 	}
 }
 
 #[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq)]
 /// Global collator state with commission fee, staked funds, and delegations
-pub struct Collator<AccountId, Balance, MaxDelegatorsPerCollator>
+pub struct Candidate<AccountId, Balance, MaxDelegatorsPerCandidate>
 where
 	AccountId: Eq + Ord + Debug,
 	Balance: Eq + Ord + Debug,
-	MaxDelegatorsPerCollator: Get<u32> + Debug + PartialEq,
+	MaxDelegatorsPerCandidate: Get<u32> + Debug + PartialEq,
 {
-	/// The collators account id.
+	/// Account id of the candidate.
 	pub id: AccountId,
 
-	/// The stake that the collator put down.
+	/// The stake that the candidate put down.
 	pub stake: Balance,
 
-	/// The delegators that back the collator.
-	pub delegators: OrderedSet<Stake<AccountId, Balance>, MaxDelegatorsPerCollator>,
+	/// The delegators that back the candidate.
+	pub delegators: OrderedSet<Stake<AccountId, Balance>, MaxDelegatorsPerCandidate>,
 
 	/// The total backing a collator has.
 	///
 	/// Should equal the sum of all delegators stake adding collators stake
 	pub total: Balance,
 
-	/// The current status of the collator. Indicates whether a collator is
-	/// active or leaving the collator set
-	pub state: CollatorStatus,
+	/// The current status of the candidate. Indicates whether a candidate is
+	/// active or leaving the candidate pool
+	pub status: CandidateStatus,
 }
 
-impl<A, B, S> Collator<A, B, S>
+impl<A, B, S> Candidate<A, B, S>
 where
 	A: Ord + Clone + Debug,
 	B: AtLeast32BitUnsigned + Ord + Copy + Saturating + Debug + Zero,
@@ -136,29 +136,29 @@ where
 {
 	pub fn new(id: A, stake: B) -> Self {
 		let total = stake;
-		Collator {
+		Candidate {
 			id,
 			stake,
 			delegators: OrderedSet::new(),
 			total,
-			state: CollatorStatus::default(), // default active
+			status: CandidateStatus::default(), // default active
 		}
 	}
 
 	pub fn is_active(&self) -> bool {
-		self.state == CollatorStatus::Active
+		self.status == CandidateStatus::Active
 	}
 
 	pub fn is_leaving(&self) -> bool {
-		matches!(self.state, CollatorStatus::Leaving(_))
+		matches!(self.status, CandidateStatus::Leaving(_))
 	}
 
 	pub fn can_exit(&self, when: u32) -> bool {
-		matches!(self.state, CollatorStatus::Leaving(at) if at <= when )
+		matches!(self.status, CandidateStatus::Leaving(at) if at <= when )
 	}
 
 	pub fn revert_leaving(&mut self) {
-		self.state = CollatorStatus::Active;
+		self.status = CandidateStatus::Active;
 	}
 
 	pub fn stake_more(&mut self, more: B) {
@@ -203,7 +203,7 @@ where
 	}
 
 	pub fn leave_candidates(&mut self, round: SessionIndex) {
-		self.state = CollatorStatus::Leaving(round);
+		self.status = CandidateStatus::Leaving(round);
 	}
 }
 
@@ -367,5 +367,5 @@ pub struct DelegationCounter {
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
-pub type CollatorOf<T, S> = Collator<AccountIdOf<T>, BalanceOf<T>, S>;
+pub type CollatorOf<T, S> = Candidate<AccountIdOf<T>, BalanceOf<T>, S>;
 pub type StakeOf<T> = Stake<AccountIdOf<T>, BalanceOf<T>>;


### PR DESCRIPTION
Refactoring part of KILTprotocol/mashnet-node/pull/244

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
