### PR TITLE
feat: improve CI checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,36 +1,36 @@
 stages:
+  - check
   - test
   - build
 
-clippy:
+check:
   image: paritytech/ci-linux:9575dfcd-20210729
-  stage: test
+  stage: check
   timeout: 1 hours
   script:
     - rustup component add clippy --toolchain nightly
-    - cargo +nightly clippy --all-features --all-targets -- -D warnings
+    - cargo +nightly clippy --workspace --all-targets --no-default-features -- -D warnings
+    - cargo +nightly clippy --workspace --all-targets --features try-runtime -- -D warnings
+    - cargo +nightly clippy --workspace --all-targets --features runtime-benchmarks -- -D warnings
+    - cargo +nightly clippy --workspace --all-targets --features mock -- -D warnings
+    - cargo +nightly clippy --workspace --all-targets --features std -- -D warnings
+    - cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings
 
 fmt:
   image: paritytech/ci-linux:9575dfcd-20210729
-  stage: test
+  stage: check
   timeout: 1 hours
   script:
     - rustup component add rustfmt --toolchain nightly
-    - cargo +nightly fmt -- --check
+    - cargo +nightly fmt --all -- --check
 
 test:
   image: paritytech/ci-linux:9575dfcd-20210729
   stage: test
   timeout: 1 hours
   script:
-    - cargo test --all --all-targets
-
-test-features:
-  image: paritytech/ci-linux:9575dfcd-20210729
-  stage: test
-  timeout: 1 hours
-  script:
-    - cargo test --all --all-features --all-targets
+    - cargo test --workspace --all-targets
+    - cargo test --workspace --all-targets --all-features
 
 build:
   image:

--- a/pallets/delegation/src/benchmarking.rs
+++ b/pallets/delegation/src/benchmarking.rs
@@ -26,7 +26,7 @@ use frame_support::{
 use frame_system::RawOrigin;
 use sp_core::{offchain::KeyTypeId, sr25519};
 use sp_io::crypto::sr25519_generate;
-use sp_runtime::MultiSignature;
+use sp_runtime::{traits::Zero, MultiSignature};
 use sp_std::{num::NonZeroU32, vec::Vec};
 
 use crate::*;

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -97,10 +97,7 @@ use frame_support::{
 	traits::{Get, ReservableCurrency},
 };
 use kilt_support::deposit::Deposit;
-use sp_runtime::{
-	traits::{Hash, Zero},
-	DispatchError,
-};
+use sp_runtime::{traits::Hash, DispatchError};
 use sp_std::vec::Vec;
 
 use migrations::*;


### PR DESCRIPTION
I keep catching Clippy warnings whenever cargo is run with a combination of features that is neither `--all-features` nor `default-features`, for instance with only `--features runtime-benchmarks`. So I thought having multiple checks in place might help to keep the code cleaner, and as all the checks are within the same CI step, it should not take THAT much longer for the checks to finish. 

If you think this is not a good idea, we can close it, but I though it would at least be worth discussing.

For reference, the [cargo check](https://doc.rust-lang.org/cargo/commands/cargo-check.html) and [cargo test](https://doc.rust-lang.org/cargo/commands/cargo-test.html) docs.