### PR TITLE
fix: unwanted delegator state removal when tx fails

### DIFF
--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1458,7 +1458,7 @@ pub mod pallet {
 				Self::update_top_candidates(collator.clone(), old_total, new_total);
 			}
 
-			// ** no fail beyond this line *
+			// *** No Fail beyond this point ***
 
 			// update states
 			<CandidatePool<T>>::insert(&collator, state);
@@ -1603,6 +1603,8 @@ pub mod pallet {
 			if state.is_active() {
 				Self::update_top_candidates(collator.clone(), old_total, new_total);
 			}
+
+			// *** No Fail beyond this point ***
 
 			// Update states
 			<CandidatePool<T>>::insert(&collator, state);
@@ -2038,7 +2040,7 @@ pub mod pallet {
 				delegator,
 				collator,
 				delegator_stake,
-				new_total,
+				new_totx1l,
 			));
 			Ok(())
 		}

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2048,12 +2048,12 @@ pub mod pallet {
 		/// Check for remaining delegations of the delegator which has been
 		/// removed from the given collator.
 		///
-		/// Returns the removed delegators address and
+		/// Returns the removed delegator's address and
 		/// * Either the updated delegator state if other delegations are still
 		///   remaining
 		/// * Or `None`, signalling the delegator state should be cleared once
 		///   the transaction cannot fail anymore.
-		fn kick_delegator(
+		fn prep_kick_delegator(
 			delegation: &StakeOf<T>,
 			collator: &T::AccountId,
 		) -> Result<ReplacedDelegator<T>, DispatchError> {
@@ -2188,7 +2188,9 @@ pub mod pallet {
 		/// amount is at most the minimum staked value of the original delegator
 		/// set, an error is returned.
 		///
-		/// Returns the old delegation that is updated, if any.
+		/// Returns a tuple which contains the updated candidate state as well
+		/// as the potentially replaced delegation which will be used later when
+		/// updating the storage of the replaced delegator.
 		///
 		/// Emits `DelegationReplaced` if the stake exceeds one of the current
 		/// delegations.
@@ -2229,7 +2231,7 @@ pub mod pallet {
 				state.total = state.total.saturating_sub(stake_to_remove.amount);
 
 				// update storage of kicked delegator
-				let kicked_delegator = Self::kick_delegator(&stake_to_remove, &state.id)?;
+				let kicked_delegator = Self::prep_kick_delegator(&stake_to_remove, &state.id)?;
 
 				Self::deposit_event(Event::DelegationReplaced(
 					stake.owner,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -172,7 +172,7 @@ mod types;
 use frame_support::pallet;
 
 pub use crate::{default_weights::WeightInfo, pallet::*};
-use types::KickedDelegator;
+use types::ReplacedDelegator;
 
 #[pallet]
 pub mod pallet {
@@ -2040,7 +2040,7 @@ pub mod pallet {
 				delegator,
 				collator,
 				delegator_stake,
-				new_totx1l,
+				new_total,
 			));
 			Ok(())
 		}
@@ -2056,7 +2056,7 @@ pub mod pallet {
 		fn kick_delegator(
 			delegation: &StakeOf<T>,
 			collator: &T::AccountId,
-		) -> Result<KickedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>, DispatchError> {
+		) -> Result<ReplacedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>, DispatchError> {
 			let mut state = <DelegatorState<T>>::get(&delegation.owner).ok_or(Error::<T>::DelegatorNotFound)?;
 			state.rm_delegation(collator);
 
@@ -2065,12 +2065,12 @@ pub mod pallet {
 
 			// return state if not empty for later removal after all checks have passed
 			if state.delegations.is_empty() {
-				Ok(KickedDelegator {
+				Ok(ReplacedDelegator {
 					who: delegation.owner.clone(),
 					state: None,
 				})
 			} else {
-				Ok(KickedDelegator {
+				Ok(ReplacedDelegator {
 					who: delegation.owner.clone(),
 					state: Some(state),
 				})
@@ -2080,14 +2080,14 @@ pub mod pallet {
 		/// Either clear the storage of a kicked delegator or update its
 		/// delegation state if it still contains other delegations.
 		fn clear_kicked_delegator_storage(
-			delegator: Option<KickedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
+			delegator: Option<ReplacedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
 		) {
 			match delegator {
-				Some(KickedDelegator {
+				Some(ReplacedDelegator {
 					who,
 					state: Some(state),
 				}) => DelegatorState::<T>::insert(who, state),
-				Some(KickedDelegator { who, .. }) => DelegatorState::<T>::remove(who),
+				Some(ReplacedDelegator { who, .. }) => DelegatorState::<T>::remove(who),
 				_ => (),
 			}
 		}
@@ -2206,7 +2206,7 @@ pub mod pallet {
 		) -> Result<
 			(
 				CandidateOf<T, T::MaxDelegatorsPerCollator>,
-				Option<KickedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
+				Option<ReplacedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
 			),
 			DispatchError,
 		> {

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2078,20 +2078,17 @@ pub mod pallet {
 		}
 
 		/// Either clear the storage of a kicked delegator or update its
-		/// delegation state.
+		/// delegation state if it still contains other delegations.
 		fn clear_kicked_delegator_storage(
 			delegator: Option<KickedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
 		) {
-			if let Some(KickedDelegator {
-				who,
-				state: maybe_state,
-			}) = delegator
-			{
-				if let Some(state) = maybe_state {
-					DelegatorState::<T>::insert(who, state);
-				} else {
-					DelegatorState::<T>::remove(who);
-				}
+			match delegator {
+				Some(KickedDelegator {
+					who,
+					state: Some(state),
+				}) => DelegatorState::<T>::insert(who, state),
+				Some(KickedDelegator { who, .. }) => DelegatorState::<T>::remove(who),
+				_ => (),
 			}
 		}
 

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -1466,7 +1466,7 @@ pub mod pallet {
 			<LastDelegation<T>>::insert(&acc, delegation_counter);
 
 			// update or clear storage of potentially kicked delegator
-			Self::clear_kicked_delegator_storage(maybe_kicked_delegator);
+			Self::update_kicked_delegator_storage(maybe_kicked_delegator);
 
 			// update candidates for next round
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
@@ -1612,7 +1612,7 @@ pub mod pallet {
 			<LastDelegation<T>>::insert(&acc, delegation_counter);
 
 			// update or clear storage of potentially kicked delegator
-			Self::clear_kicked_delegator_storage(maybe_kicked_delegator);
+			Self::update_kicked_delegator_storage(maybe_kicked_delegator);
 
 			// update candidates for next round
 			let (num_collators, num_delegators, _, _) = Self::update_total_stake();
@@ -2079,7 +2079,7 @@ pub mod pallet {
 
 		/// Either clear the storage of a kicked delegator or update its
 		/// delegation state if it still contains other delegations.
-		fn clear_kicked_delegator_storage(delegator: Option<ReplacedDelegator<T>>) {
+		fn update_kicked_delegator_storage(delegator: Option<ReplacedDelegator<T>>) {
 			match delegator {
 				Some(ReplacedDelegator {
 					who,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -2056,7 +2056,7 @@ pub mod pallet {
 		fn kick_delegator(
 			delegation: &StakeOf<T>,
 			collator: &T::AccountId,
-		) -> Result<ReplacedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>, DispatchError> {
+		) -> Result<ReplacedDelegator<T>, DispatchError> {
 			let mut state = <DelegatorState<T>>::get(&delegation.owner).ok_or(Error::<T>::DelegatorNotFound)?;
 			state.rm_delegation(collator);
 
@@ -2079,9 +2079,7 @@ pub mod pallet {
 
 		/// Either clear the storage of a kicked delegator or update its
 		/// delegation state if it still contains other delegations.
-		fn clear_kicked_delegator_storage(
-			delegator: Option<ReplacedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
-		) {
+		fn clear_kicked_delegator_storage(delegator: Option<ReplacedDelegator<T>>) {
 			match delegator {
 				Some(ReplacedDelegator {
 					who,
@@ -2200,13 +2198,14 @@ pub mod pallet {
 		/// bounded by `MaxDelegatorsPerCollator`.
 		/// - Reads/Writes: 0
 		/// # </weight>
+		#[allow(clippy::type_complexity)]
 		fn do_update_delegator(
 			stake: Stake<T::AccountId, BalanceOf<T>>,
 			mut state: Candidate<T::AccountId, BalanceOf<T>, T::MaxDelegatorsPerCollator>,
 		) -> Result<
 			(
 				CandidateOf<T, T::MaxDelegatorsPerCollator>,
-				Option<ReplacedDelegator<T::AccountId, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
+				Option<ReplacedDelegator<T>>,
 			),
 			DispatchError,
 		> {

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -30,6 +30,7 @@ mod v2;
 mod v3;
 mod v4;
 mod v5;
+mod v6;
 
 /// A trait that allows version migrators to access the underlying pallet's
 /// context, e.g., its Config trait.
@@ -55,6 +56,7 @@ pub enum StakingStorageVersion {
 	V3_0_0, // Update InflationConfig
 	V4,     // Sort TopCandidates and parachain-stakings by amount
 	V5,     // Remove SelectedCandidates, Count Candidates
+	V6,     // Fix delegator replacement bug
 }
 
 #[cfg(feature = "try-runtime")]
@@ -87,7 +89,8 @@ impl<T: Config> VersionMigratorTrait<T> for StakingStorageVersion {
 			Self::V2_0_0 => v3::pre_migrate::<T>(),
 			Self::V3_0_0 => v4::pre_migrate::<T>(),
 			Self::V4 => v5::pre_migrate::<T>(),
-			Self::V5 => Ok(()),
+			Self::V5 => v6::pre_migrate::<T>(),
+			Self::V6 => Ok(()),
 		}
 	}
 
@@ -98,7 +101,8 @@ impl<T: Config> VersionMigratorTrait<T> for StakingStorageVersion {
 			Self::V2_0_0 => v3::migrate::<T>(),
 			Self::V3_0_0 => v4::migrate::<T>(),
 			Self::V4 => v5::migrate::<T>(),
-			Self::V5 => Weight::zero(),
+			Self::V5 => v6::migrate::<T>(),
+			Self::V6 => Weight::zero(),
 		}
 	}
 
@@ -111,7 +115,8 @@ impl<T: Config> VersionMigratorTrait<T> for StakingStorageVersion {
 			Self::V2_0_0 => v3::post_migrate::<T>(),
 			Self::V3_0_0 => v4::post_migrate::<T>(),
 			Self::V4 => v5::post_migrate::<T>(),
-			Self::V5 => Ok(()),
+			Self::V5 => v6::post_migrate::<T>(),
+			Self::V6 => Ok(()),
 		}
 	}
 }
@@ -133,7 +138,8 @@ impl<T: Config> StakingStorageMigrator<T> {
 			// Migration happens naturally, no need to point to the latest version
 			StakingStorageVersion::V3_0_0 => Some(StakingStorageVersion::V4),
 			StakingStorageVersion::V4 => Some(StakingStorageVersion::V5),
-			StakingStorageVersion::V5 => None,
+			StakingStorageVersion::V5 => Some(StakingStorageVersion::V6),
+			StakingStorageVersion::V6 => None,
 		}
 	}
 

--- a/pallets/parachain-staking/src/migrations/v6.rs
+++ b/pallets/parachain-staking/src/migrations/v6.rs
@@ -1,0 +1,73 @@
+// KILT Blockchain – https://botlabs.org
+// Copyright (C) 2019-2021 BOTLabs GmbH
+
+// The KILT Blockchain is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The KILT Blockchain is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// If you feel like getting in touch with us, you can do so at info@botlabs.org
+
+use frame_support::{dispatch::Weight, traits::Get};
+
+use crate::{
+	migrations::StakingStorageVersion, types::Delegator, CandidatePool, Config, DelegatorState, StorageVersion,
+};
+
+#[cfg(feature = "try-runtime")]
+pub(crate) fn pre_migrate<T: Config>() -> Result<(), &'static str> {
+	assert_eq!(StorageVersion::<T>::get(), StakingStorageVersion::V5);
+	Ok(())
+}
+
+pub(crate) fn migrate<T: Config>() -> Weight {
+	log::info!("Migrating staking to StakingStorageVersion::V6");
+
+	let mut reads = 0u64;
+	let mut writes = 1u64;
+
+	// iter candidate pool and check whether any delegator has a cleared state
+	for candidate in CandidatePool::<T>::iter_values() {
+		reads = reads.saturating_add(1u64);
+		for delegation in candidate.delegators.into_iter() {
+			// since MaxCollatorsPerDelegator == 1, we do not have to mutate existing
+			// entries
+			if !DelegatorState::<T>::contains_key(delegation.owner.clone()) {
+				DelegatorState::<T>::insert(
+					delegation.owner,
+					Delegator::try_new(candidate.id.clone(), delegation.amount)
+						.expect("MaxCollatorsPerDelegator is greater than one"),
+				);
+				writes = writes.saturating_add(1u64);
+			}
+			reads = reads.saturating_add(1u64);
+		}
+	}
+
+	// update storage version
+	StorageVersion::<T>::put(StakingStorageVersion::V6);
+	log::info!("Completed staking migration to StakingStorageVersion::V6");
+
+	T::DbWeight::get().reads_writes(reads, writes)
+}
+
+#[cfg(feature = "try-runtime")]
+pub(crate) fn post_migrate<T: Config>() -> Result<(), &'static str> {
+	assert_eq!(StorageVersion::<T>::get(), StakingStorageVersion::V6);
+
+	for candidate in CandidatePool::<T>::iter_values() {
+		for delegation in candidate.delegators.into_iter() {
+			assert!(DelegatorState::<T>::contains_key(delegation.owner));
+		}
+	}
+
+	Ok(())
+}

--- a/pallets/parachain-staking/src/migrations/v6.rs
+++ b/pallets/parachain-staking/src/migrations/v6.rs
@@ -38,8 +38,7 @@ pub(crate) fn migrate<T: Config>() -> Weight {
 	for candidate in CandidatePool::<T>::iter_values() {
 		reads = reads.saturating_add(1u64);
 		for delegation in candidate.delegators.into_iter() {
-			// since MaxCollatorsPerDelegator == 1, we do not have to mutate existing
-			// entries
+			// we do not have to mutate existing entries since MaxCollatorsPerDelegator = 1
 			if !DelegatorState::<T>::contains_key(delegation.owner.clone()) {
 				DelegatorState::<T>::insert(
 					delegation.owner,

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -346,7 +346,7 @@ fn collator_exit_executes_after_delay() {
 		.with_balances(vec![
 			(1, 1000),
 			(2, 300),
-			(3, 100),
+			(3, 110),
 			(4, 100),
 			(5, 100),
 			(6, 100),
@@ -2595,7 +2595,7 @@ fn kick_delegator_with_full_unstaking() {
 
 #[test]
 fn candidate_leaves() {
-	let balances: Vec<(AccountId, Balance)> = (1u64..15u64).map(|id| (id, 100)).collect();
+	let balances: Vec<(AccountId, Balance)> = (1u64..=15u64).map(|id| (id, 100)).collect();
 	ExtBuilder::default()
 		.with_balances(balances)
 		.with_collators(vec![(1, 100), (2, 100)])
@@ -3464,4 +3464,45 @@ fn force_new_round() {
 			assert_eq!(Session::validators(), vec![3, 4]);
 			assert!(!StakePallet::new_round_forced());
 		});
+}
+
+#[test]
+fn replace_lowest_delegator() {
+	ExtBuilder::default()
+		.with_balances(vec![(1, 100), (2, 100), (3, 100), (4, 100), (5, 100), (6, 100)])
+		.with_collators(vec![(1, 100)])
+		.with_delegators(vec![(2, 1, 51), (3, 1, 51), (4, 1, 51), (5, 1, 50)])
+		.build()
+		.execute_with(|| {
+			assert_eq!(
+				StakePallet::candidate_pool(1).unwrap().delegators.len() as u32,
+				<Test as Config>::MaxDelegatorsPerCollator::get()
+			);
+
+			// 6 replaces 5
+			assert_ok!(StakePallet::join_delegators(Origin::signed(6), 1, 51));
+			assert!(StakePallet::delegator_state(5).is_none());
+			assert_eq!(
+				StakePallet::candidate_pool(1)
+					.unwrap()
+					.delegators
+					.into_bounded_vec()
+					.into_inner(),
+				vec![
+					Stake { owner: 2, amount: 51 },
+					Stake { owner: 3, amount: 51 },
+					Stake { owner: 4, amount: 51 },
+					Stake { owner: 6, amount: 51 }
+				]
+			);
+
+			// 5 attempts to replace 6 with more balance than available
+			// FIXME: Should be assert_noop!
+			frame_support::assert_noop!(
+				StakePallet::join_delegators(Origin::signed(5), 1, 101),
+				BalancesError::<Test>::InsufficientBalance
+			);
+			// FIXME: Should be some
+			assert!(StakePallet::delegator_state(6).is_some());
+		})
 }

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -3497,12 +3497,10 @@ fn replace_lowest_delegator() {
 			);
 
 			// 5 attempts to replace 6 with more balance than available
-			// FIXME: Should be assert_noop!
 			frame_support::assert_noop!(
 				StakePallet::join_delegators(Origin::signed(5), 1, 101),
 				BalancesError::<Test>::InsufficientBalance
 			);
-			// FIXME: Should be some
 			assert!(StakePallet::delegator_state(6).is_some());
 		})
 }

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -365,6 +365,12 @@ pub struct DelegationCounter {
 	pub counter: u32,
 }
 
+///
+pub(crate) struct KickedDelegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
+	pub who: AccountId,
+	pub state: Option<Delegator<AccountId, Balance, MaxCollatorsPerDelegator>>,
+}
+
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type BalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
 pub type CandidateOf<T, S> = Candidate<AccountIdOf<T>, BalanceOf<T>, S>;

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -367,9 +367,9 @@ pub struct DelegationCounter {
 
 /// Internal type which is used if a delegator is replaced by another one to
 /// delay the storage entry removal until failure cannot happen anymore.
-pub(crate) struct ReplacedDelegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
-	pub who: AccountId,
-	pub state: Option<Delegator<AccountId, Balance, MaxCollatorsPerDelegator>>,
+pub(crate) struct ReplacedDelegator<T: Config> {
+	pub who: AccountIdOf<T>,
+	pub state: Option<Delegator<AccountIdOf<T>, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,
 }
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -365,7 +365,8 @@ pub struct DelegationCounter {
 	pub counter: u32,
 }
 
-///
+/// Internal type which is used if a delegator is replaced by another one to
+/// delay the storage entry removal until failure cannot happen anymore.
 pub(crate) struct KickedDelegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
 	pub who: AccountId,
 	pub state: Option<Delegator<AccountId, Balance, MaxCollatorsPerDelegator>>,

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -365,8 +365,8 @@ pub struct DelegationCounter {
 	pub counter: u32,
 }
 
-/// Internal type which is used if a delegator is replaced by another one to
-/// delay the storage entry removal until failure cannot happen anymore.
+/// Internal type which is only used when a delegator is replaced by another
+/// one to delay the storage entry removal until failure cannot happen anymore.
 pub(crate) struct ReplacedDelegator<T: Config> {
 	pub who: AccountIdOf<T>,
 	pub state: Option<Delegator<AccountIdOf<T>, BalanceOf<T>, T::MaxCollatorsPerDelegator>>,

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -367,7 +367,7 @@ pub struct DelegationCounter {
 
 /// Internal type which is used if a delegator is replaced by another one to
 /// delay the storage entry removal until failure cannot happen anymore.
-pub(crate) struct KickedDelegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
+pub(crate) struct ReplacedDelegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
 	pub who: AccountId,
 	pub state: Option<Delegator<AccountId, Balance, MaxCollatorsPerDelegator>>,
 }


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1632
* Fixes unwanted removal of delegator state if `join_delegators` or `delegate_another_candidate` extrinsics failed due to failure in `increase_lock` (either insufficient balance or full unstaking list) by delaying removal until tx cannot fail anymore
* Adds balance checks to head of corresponding delegation extrinsics
* Adds corresponding unit test

### TODO

- [x] Write migration for delegator which does not have a `DelegatorState` anymore but is still delegating to a collator


## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
