### PR TITLE
chore: fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,22 @@ RUN cargo build --release --features $FEATURES
 
 # ===== SECOND STAGE ======
 
-FROM debian:buster-slim
+FROM docker.io/library/ubuntu:20.04
 LABEL description="This is the 2nd stage: a very small image where we copy the kilt-parachain binary."
 
 ARG NODE_TYPE=kilt-parachain
+
+# install tools and dependencies
+RUN apt-get update && \
+       DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+       DEBIAN_FRONTEND=noninteractive apt-get install -y \
+               libssl1.1 \
+               ca-certificates \
+               curl && \
+# apt cleanup
+       apt-get autoremove -y && \
+       apt-get clean && \
+       find /var/lib/apt/lists/ -type f -not -name lock -delete
 
 COPY ./LICENSE /build/LICENSE
 COPY ./README.md /build/README.md


### PR DESCRIPTION
## No-Ticket
The integration tests on the SDK were failing, because the docker image for the standalone chain was panicking with following error:
```
Thread 'main' panicked at 'no CA certificates found',
```

Here is someone else having the same problem: https://github.com/paritytech/substrate/issues/9984

I modified the Dockerfile to include the certificates. I was following substrates maintain Dockerfile here: https://github.com/paritytech/substrate/blob/7fbec2f9d22adc6bf968a048d768b2e30b46ac30/.maintain/docker/substrate.Dockerfile

It might not be necessary to switch to the ubuntu image. I did that, because I couldn't install anything in the docker image manually (while running it with `/bin/bash`) and substrate has switched to it: https://github.com/paritytech/substrate/pull/9753. It turns out, that apt-get and similar are missing, because the whole `usr` binaries are removed: https://github.com/KILTprotocol/mashnet-node/blob/develop/Dockerfile#L34.

**Do we really need to remove all these binaries?
Is it ok to switch to the ubuntu image?**

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
