### PR TITLE
fix: missing migrations for collective and membership pallets

### DIFF
--- a/pallets/delegation/src/migrations.rs
+++ b/pallets/delegation/src/migrations.rs
@@ -47,7 +47,7 @@ impl DelegationStorageVersion {
 // old version anymore.
 impl Default for DelegationStorageVersion {
 	fn default() -> Self {
-		Self::V1
+		Self::V2
 	}
 }
 
@@ -153,7 +153,7 @@ impl<T: Config> DelegationStorageMigrator<T> {
 	pub(crate) fn post_migrate() -> Result<(), &'static str> {
 		ensure!(
 			StorageVersion::<T>::get() == DelegationStorageVersion::latest(),
-			"Not updated to the latest version."
+			"Delegations not updated to the latest version."
 		);
 
 		Ok(())

--- a/pallets/did/src/migrations.rs
+++ b/pallets/did/src/migrations.rs
@@ -159,7 +159,7 @@ impl<T: Config> DidStorageMigrator<T> {
 	pub(crate) fn post_migrate() -> Result<(), &'static str> {
 		ensure!(
 			StorageVersion::<T>::get() == DidStorageVersion::latest(),
-			"Not updated to the latest version."
+			"DID not updated to the latest version."
 		);
 
 		Ok(())

--- a/pallets/parachain-staking/src/migrations.rs
+++ b/pallets/parachain-staking/src/migrations.rs
@@ -191,7 +191,7 @@ impl<T: Config> StakingStorageMigrator<T> {
 	pub(crate) fn post_migrate() -> Result<(), &'static str> {
 		ensure!(
 			StorageVersion::<T>::get() == StakingStorageVersion::latest(),
-			"Not updated to the latest version."
+			"Staking not updated to the latest version."
 		);
 
 		Ok(())

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -844,8 +844,20 @@ pub type Executive = frame_executive::Executive<
 		CouncilStoragePrefixMigration,
 		TechnicalCommitteeStoragePrefixMigration,
 		TechnicalMembershipStoragePrefixMigration,
+		MigratePalletVersionToStorageVersion,
 	),
 >;
+
+/// Migrate from `PalletVersion` to the new `StorageVersion`
+pub struct MigratePalletVersionToStorageVersion;
+
+impl OnRuntimeUpgrade for MigratePalletVersionToStorageVersion {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		frame_support::migrations::migrate_from_pallet_version_to_storage_version::<AllPalletsWithSystem>(
+			&RocksDbWeight::get(),
+		)
+	}
+}
 
 const COUNCIL_OLD_PREFIX: &str = "Instance1Collective";
 /// Migrate from `Instance1Collective` to the new pallet prefix `Council`

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 10100,
+	spec_version: 10101,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -80,8 +80,6 @@ use sp_version::NativeVersion;
 #[cfg(feature = "runtime-benchmarks")]
 use {frame_system::EnsureSigned, kilt_primitives::benchmarks::DummySignature, kilt_support::signature::AlwaysVerify};
 
-use migrations::crowdloan_contributions::CrowdloanContributionsSetup;
-
 mod fee;
 mod migrations;
 #[cfg(test)]

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -841,7 +841,6 @@ pub type Executive = frame_executive::Executive<
 	Runtime,
 	AllPallets,
 	(
-		CrowdloanContributionsSetup,
 		CouncilStoragePrefixMigration,
 		TechnicalCommitteeStoragePrefixMigration,
 		TechnicalMembershipStoragePrefixMigration,

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kilt-spiritnet"),
 	impl_name: create_runtime_str!("kilt-spiritnet"),
 	authoring_version: 1,
-	spec_version: 10100,
+	spec_version: 10101,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -27,7 +27,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 use frame_support::{
 	construct_runtime, parameter_types,
-	traits::Contains,
+	traits::{Contains, OnRuntimeUpgrade},
 	weights::{constants::RocksDbWeight, Weight},
 	PalletId,
 };
@@ -369,7 +369,7 @@ impl pallet_democracy::Config for Runtime {
 	type Event = Event;
 	type Currency = Balances;
 	type EnactmentPeriod = EnactmentPeriod;
-	type VoteLockingPeriod = EnactmentPeriod;
+	type VoteLockingPeriod = VotingPeriod;
 	type LaunchPeriod = LaunchPeriod;
 	type VotingPeriod = VotingPeriod;
 	type MinimumDeposit = MinimumDeposit;
@@ -854,8 +854,96 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
-	CrowdloanContributionsSetup,
+	(
+		CrowdloanContributionsSetup,
+		CouncilStoragePrefixMigration,
+		TechnicalCommitteeStoragePrefixMigration,
+		TechnicalMembershipStoragePrefixMigration,
+	),
 >;
+
+const COUNCIL_OLD_PREFIX: &str = "Instance1Collective";
+/// Migrate from `Instance1Collective` to the new pallet prefix `Council`
+pub struct CouncilStoragePrefixMigration;
+
+impl OnRuntimeUpgrade for CouncilStoragePrefixMigration {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		pallet_collective::migrations::v4::migrate::<Runtime, Council, _>(COUNCIL_OLD_PREFIX)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		pallet_collective::migrations::v4::pre_migrate::<Council, _>(COUNCIL_OLD_PREFIX);
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		pallet_collective::migrations::v4::post_migrate::<Council, _>(COUNCIL_OLD_PREFIX);
+		Ok(())
+	}
+}
+
+const TECHNICAL_COMMITTEE_OLD_PREFIX: &str = "Instance2Collective";
+/// Migrate from `Instance2Collective` to the new pallet prefix
+/// `TechnicalCommittee`
+pub struct TechnicalCommitteeStoragePrefixMigration;
+
+impl OnRuntimeUpgrade for TechnicalCommitteeStoragePrefixMigration {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		pallet_collective::migrations::v4::migrate::<Runtime, TechnicalCommittee, _>(TECHNICAL_COMMITTEE_OLD_PREFIX)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		pallet_collective::migrations::v4::pre_migrate::<TechnicalCommittee, _>(TECHNICAL_COMMITTEE_OLD_PREFIX);
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		pallet_collective::migrations::v4::post_migrate::<TechnicalCommittee, _>(TECHNICAL_COMMITTEE_OLD_PREFIX);
+		Ok(())
+	}
+}
+
+const TECHNICAL_MEMBERSHIP_OLD_PREFIX: &str = "Instance1Membership";
+/// Migrate from `Instance1Membership` to the new pallet prefix
+/// `TechnicalMembership`
+pub struct TechnicalMembershipStoragePrefixMigration;
+
+impl OnRuntimeUpgrade for TechnicalMembershipStoragePrefixMigration {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		use frame_support::traits::PalletInfo;
+		let name = <Runtime as frame_system::Config>::PalletInfo::name::<TechnicalMembership>()
+			.expect("TechnicalMembership is part of runtime, so it has a name; qed");
+		pallet_membership::migrations::v4::migrate::<Runtime, TechnicalMembership, _>(
+			TECHNICAL_MEMBERSHIP_OLD_PREFIX,
+			name,
+		)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::PalletInfo;
+		let name = <Runtime as frame_system::Config>::PalletInfo::name::<TechnicalMembership>()
+			.expect("TechnicalMembership is part of runtime, so it has a name; qed");
+		pallet_membership::migrations::v4::pre_migrate::<TechnicalMembership, _>(TECHNICAL_MEMBERSHIP_OLD_PREFIX, name);
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade() -> Result<(), &'static str> {
+		use frame_support::traits::PalletInfo;
+		let name = <Runtime as frame_system::Config>::PalletInfo::name::<TechnicalMembership>()
+			.expect("TechnicalMembership is part of runtime, so it has a name; qed");
+		pallet_membership::migrations::v4::post_migrate::<TechnicalMembership, _>(
+			TECHNICAL_MEMBERSHIP_OLD_PREFIX,
+			name,
+		);
+		Ok(())
+	}
+}
 
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -859,8 +859,20 @@ pub type Executive = frame_executive::Executive<
 		CouncilStoragePrefixMigration,
 		TechnicalCommitteeStoragePrefixMigration,
 		TechnicalMembershipStoragePrefixMigration,
+		MigratePalletVersionToStorageVersion,
 	),
 >;
+
+/// Migrate from `PalletVersion` to the new `StorageVersion`
+pub struct MigratePalletVersionToStorageVersion;
+
+impl OnRuntimeUpgrade for MigratePalletVersionToStorageVersion {
+	fn on_runtime_upgrade() -> frame_support::weights::Weight {
+		frame_support::migrations::migrate_from_pallet_version_to_storage_version::<AllPalletsWithSystem>(
+			&RocksDbWeight::get(),
+		)
+	}
+}
 
 const COUNCIL_OLD_PREFIX: &str = "Instance1Collective";
 /// Migrate from `Instance1Collective` to the new pallet prefix `Council`

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -124,7 +124,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 10100,
+	spec_version: 10101,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
* Adds missing migrations for collective and membership pallets which moves the pallets storage from an old prefix to a new one
* Includes fixes for StorageVersions of delegations and parachain-staking (cherry-picked from #285)
* Requires clearing storage items for new prefix and setting storage version to non-default beforehand (see Requirements)

- [x] Peregrine Stg prepared
- [x] Peregrine prepared
- [x] WILT prepared
- [ ] Spiritnet prepared

## How to test

Tested with `try-runtime` for

- [x] Peregrine Stg
- [x] Peregrine
- [x] WILT

1. In your `.cargo/.../frame/vesting/src/migrations.rs` remove this pre-migration check:
```
// assert!(StorageVersion::<T>::get() == Releases::V0, "Storage version too high.");
```

2a. For WILT run
```
cargo run --release -p kilt-parachain --features try-runtime -- try-runtime --chain=spiritnet-dev --execution=native  on-runtime-upgrade live --uri=wss://westend.kilt.io/
```

2b. For Peregrine run
```
cargo run --release -p kilt-parachain --features try-runtime -- try-runtime --chain=dev --execution=native  on-runtime-upgrade live --uri=wss://peregrine.kilt.io
```

## Requirements

1. Kill `PalletVersion` storage items for new prefix. Unfortunately, setting the storage items to `0x` does not suffice, at least in `try-runtime`.
```
// Council
System.killPrefix(0xaebd463ed9925c488c112434d61debc0, 1)
// TechnicalCommittee
System.killPrefix(0xed25f63942de25ac5253ba64b5eb64d1, 1)
// TechnicalMembership
System.killPrefix(0x3a2d6c9353500637d8f8e3e0fa0bb1c5, 1)
```

2. Set some raw storage items beforehand because...
1) We have no StorageVersion set for the collective pallets and the membership pallet. Thus, the default value is taken which prevents the migration from being enacted.
2) We have not updated the StorageVersions for our Delegation and ParachainStaking pallets after the last migration

```
{
    // Council + :__STORAGE_VERSION__:
    "0xaebd463ed9925c488c112434d61debc04e7b9012096b41c4eb3aaf947f6ea429": "0x0000",
    // TechnicalCommittee + :__STORAGE_VERSION__:
    "0xed25f63942de25ac5253ba64b5eb64d14e7b9012096b41c4eb3aaf947f6ea429": "0x0000",
    // TechnicalMembership + :__STORAGE_VERSION__:
    "0x3a2d6c9353500637d8f8e3e0fa0bb1c54e7b9012096b41c4eb3aaf947f6ea429": "0x0000",
    // Instance1Collective+ :__STORAGE_VERSION__:
    "0x11f3ba2e1cdd6d62f2ff9b5589e7ff814e7b9012096b41c4eb3aaf947f6ea429": "0x0000",
    // Instance2Collective + :__STORAGE_VERSION__:
    "0x492a52699edf49c972c21db794cfcf574e7b9012096b41c4eb3aaf947f6ea429": "0x0000",
    // Instance1Membership + :__STORAGE_VERSION__:
    "0x8985776095addd4789fccbce8ca77b234e7b9012096b41c4eb3aaf947f6ea429": "0x0000",
    // Delegation + StorageVersion
    "0x52da4aa879a49f588394d236e8a0642f308ce9615de0775a82f8a94dc3d285a1": "0x01",
    // ParachainStaking + StorageVersion
    "0xa686a3043d0adcf2fa655e57bc595a78308ce9615de0775a82f8a94dc3d285a1": "0x05"
}
```

### Proof of JSON

Generated via substrage-storage-playground
```
":__STORAGE_VERSION__:" => "4e7b9012096b41c4eb3aaf947f6ea429"
"Council" => "aebd463ed9925c488c112434d61debc0"
"Delegation" => "52da4aa879a49f588394d236e8a0642f"
"Instance1Collective" => "11f3ba2e1cdd6d62f2ff9b5589e7ff81"
"Instance1Membership" => "492a52699edf49c972c21db794cfcf57"
"Instance2Collective" => "8985776095addd4789fccbce8ca77b23"
"ParachainStaking" => "a686a3043d0adcf2fa655e57bc595a78"
"StorageVersion" => "308ce9615de0775a82f8a94dc3d285a1"
"TechnicalCommittee" => "ed25f63942de25ac5253ba64b5eb64d1"
"TechnicalMembership" => "3a2d6c9353500637d8f8e3e0fa0bb1c5"
"StakingStorageVersion::V6" => "05"
"DelegationStorageVersion::V2" => "01"
"3_u16" => "0300"
```