### PR TITLE
feat: add lazy total stake calculation

### DIFF
--- a/pallets/parachain-staking/src/benchmarking.rs
+++ b/pallets/parachain-staking/src/benchmarking.rs
@@ -234,6 +234,7 @@ benchmarks! {
 		assert!(!candidates.into_iter().any(|other| other.owner == candidate));
 	}
 
+	// TODO: Remove (n, m) params
 	join_candidates {
 		let n in 1 .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
@@ -273,6 +274,7 @@ benchmarks! {
 		assert!(<CandidatePool<T>>::get(candidate).unwrap().can_exit(unlocking_at));
 	}
 
+	// TODO: Remove (n, m) params
 	cancel_leave_candidates {
 		let n in (T::MinCollators::get() + 1) .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
@@ -327,6 +329,7 @@ benchmarks! {
 		assert_eq!(<Unstaking<T>>::get(&candidate).len().saturated_into::<u32>(), u.saturating_add(1u32));
 	}
 
+	// TODO: Remove (n, m) params
 	candidate_stake_more {
 		let n in 1 .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
@@ -355,6 +358,7 @@ benchmarks! {
 		assert_eq!(new_stake, old_stake + more_stake + more_stake - T::CurrencyBalance::from(u as u64));
 	}
 
+	// TODO: Remove (n, m) params
 	candidate_stake_less {
 		let n in 1 .. T::MaxTopCandidates::get() - 1;
 		let m in 0 .. T::MaxDelegatorsPerCollator::get();
@@ -381,6 +385,7 @@ benchmarks! {
 		assert_eq!(new_stake, old_stake);
 	}
 
+	// TODO: Remove (n, m) params
 	join_delegators {
 		let n in 1 .. T::MaxTopCandidates::get();
 		let m in 1 .. T::MaxDelegatorsPerCollator::get() - 1;
@@ -401,6 +406,7 @@ benchmarks! {
 		assert!(state.delegators.into_iter().any(|x| x.owner == delegator));
 	}
 
+	// TODO: Remove (n, m) params
 	delegator_stake_more {
 		// we need at least 1 collators
 		let n in 1 .. T::MaxTopCandidates::get();
@@ -437,6 +443,7 @@ benchmarks! {
 		assert!(<Unstaking<T>>::get(&delegator).is_empty());
 	}
 
+	// TODO: Remove (n, m) params
 	delegator_stake_less {
 		// we need at least 1 collators
 		let n in 1 .. T::MaxTopCandidates::get();
@@ -474,6 +481,7 @@ benchmarks! {
 		assert_eq!(<Unstaking<T>>::get(&delegator).len(), 2);
 	}
 
+	// TODO: Remove (n, m) params
 	revoke_delegation {
 		// we need at least 1 collators
 		let n in 1 .. T::MaxTopCandidates::get();
@@ -511,6 +519,7 @@ benchmarks! {
 		assert_eq!(<Unstaking<T>>::get(&delegator).len(), 2);
 	}
 
+	// TODO: Remove (n, m) params
 	leave_delegators {
 		// we need at least 1 collators
 		let n in 1 .. T::MaxTopCandidates::get();

--- a/pallets/parachain-staking/src/default_weights.rs
+++ b/pallets/parachain-staking/src/default_weights.rs
@@ -56,17 +56,17 @@ pub trait WeightInfo {
 	fn set_max_selected_candidates(n: u32, m: u32, ) -> Weight;
 	fn set_blocks_per_round() -> Weight;
 	fn force_remove_candidate(n: u32, m: u32, ) -> Weight;
-	fn join_candidates(n: u32, m: u32, ) -> Weight;
+	fn join_candidates() -> Weight;
 	fn init_leave_candidates(n: u32, m: u32, ) -> Weight;
-	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight;
+	fn cancel_leave_candidates() -> Weight;
 	fn execute_leave_candidates(n: u32, m: u32, u: u32, ) -> Weight;
-	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight;
-	fn candidate_stake_less(n: u32, m: u32, ) -> Weight;
-	fn join_delegators(n: u32, m: u32, ) -> Weight;
-	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight;
-	fn delegator_stake_less(n: u32, m: u32, ) -> Weight;
-	fn revoke_delegation(n: u32, m: u32, ) -> Weight;
-	fn leave_delegators(n: u32, m: u32, ) -> Weight;
+	fn candidate_stake_more(u: u32, ) -> Weight;
+	fn candidate_stake_less() -> Weight;
+	fn join_delegators() -> Weight;
+	fn delegator_stake_more(u: u32, ) -> Weight;
+	fn delegator_stake_less() -> Weight;
+	fn revoke_delegation( ) -> Weight;
+	fn leave_delegators(n: u32, ) -> Weight;
 	fn unlock_unstaked(u: u32, ) -> Weight;
 	fn set_max_candidate_stake() -> Weight;
 }
@@ -165,12 +165,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking CandidateCount (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_candidates(n: u32, m: u32, ) -> Weight {
+	fn join_candidates() -> Weight {
 		(83_635_000 as Weight)
-			// Standard Error: 58_000
-			.saturating_add((4_079_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 213_000
-			.saturating_add((9_583_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(18 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
@@ -192,12 +188,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
+	fn cancel_leave_candidates() -> Weight {
 		(137_072_000 as Weight)
-			// Standard Error: 11_000
-			.saturating_add((2_550_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 31_000
-			.saturating_add((8_705_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(19 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
@@ -216,9 +208,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			// Standard Error: 39_000
 			.saturating_add((28_966_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -228,12 +218,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn candidate_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 64_000
-			.saturating_add((4_847_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 237_000
-			.saturating_add((12_324_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 905_000
 			.saturating_add((6_229_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
@@ -244,12 +230,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
+	fn candidate_stake_less() -> Weight {
 		(0 as Weight)
-			// Standard Error: 70_000
-			.saturating_add((4_804_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 257_000
-			.saturating_add((12_130_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -263,12 +245,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_delegators(n: u32, m: u32, ) -> Weight {
+	fn join_delegators() -> Weight {
 		(38_983_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_884_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 284_000
-			.saturating_add((12_982_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(18 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 	}
@@ -280,12 +258,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn delegator_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 65_000
-			.saturating_add((4_805_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 273_000
-			.saturating_add((12_728_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 1_092_000
 			.saturating_add((7_634_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
@@ -297,12 +271,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
+	fn delegator_stake_less() -> Weight {
 		(5_521_000 as Weight)
-			// Standard Error: 72_000
-			.saturating_add((4_556_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 297_000
-			.saturating_add((12_025_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -312,12 +282,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
+	fn revoke_delegation( ) -> Weight {
 		(29_370_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_356_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 287_000
-			.saturating_add((11_536_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -327,12 +293,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn leave_delegators(n: u32, m: u32, ) -> Weight {
+	fn leave_delegators(n: u32, ) -> Weight {
 		(25_052_000 as Weight)
 			// Standard Error: 68_000
 			.saturating_add((4_397_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 283_000
-			.saturating_add((11_569_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -434,7 +398,6 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(25 as Weight))
 			.saturating_add(RocksDbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
-			.saturating_add(RocksDbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:3 w:1)
 	// Storage: ParachainStaking DelegatorState (r:1 w:0)
@@ -446,12 +409,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking CandidateCount (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_candidates(n: u32, m: u32, ) -> Weight {
+	fn join_candidates() -> Weight {
 		(83_635_000 as Weight)
-			// Standard Error: 58_000
-			.saturating_add((4_079_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 213_000
-			.saturating_add((9_583_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(18 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(7 as Weight))
 	}
@@ -473,12 +432,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
+	fn cancel_leave_candidates() -> Weight {
 		(137_072_000 as Weight)
-			// Standard Error: 11_000
-			.saturating_add((2_550_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 31_000
-			.saturating_add((8_705_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(19 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
 	}
@@ -509,12 +464,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn candidate_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 64_000
-			.saturating_add((4_847_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 237_000
-			.saturating_add((12_324_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 905_000
 			.saturating_add((6_229_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
@@ -525,12 +476,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
+	fn candidate_stake_less() -> Weight {
 		(0 as Weight)
-			// Standard Error: 70_000
-			.saturating_add((4_804_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 257_000
-			.saturating_add((12_130_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(12 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(4 as Weight))
 	}
@@ -544,12 +491,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_delegators(n: u32, m: u32, ) -> Weight {
+	fn join_delegators() -> Weight {
 		(38_983_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_884_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 284_000
-			.saturating_add((12_982_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(18 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(8 as Weight))
 	}
@@ -561,12 +504,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn delegator_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 65_000
-			.saturating_add((4_805_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 273_000
-			.saturating_add((12_728_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 1_092_000
 			.saturating_add((7_634_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(RocksDbWeight::get().reads(12 as Weight))
@@ -578,12 +517,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
+	fn delegator_stake_less() -> Weight {
 		(5_521_000 as Weight)
-			// Standard Error: 72_000
-			.saturating_add((4_556_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 297_000
-			.saturating_add((12_025_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
@@ -593,12 +528,8 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
+	fn revoke_delegation( ) -> Weight {
 		(29_370_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_356_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 287_000
-			.saturating_add((11_536_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
@@ -608,12 +539,10 @@ impl WeightInfo for () {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn leave_delegators(n: u32, m: u32, ) -> Weight {
+	fn leave_delegators(n: u32, ) -> Weight {
 		(25_052_000 as Weight)
 			// Standard Error: 68_000
 			.saturating_add((4_397_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 283_000
-			.saturating_add((11_569_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(RocksDbWeight::get().reads(13 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -101,7 +101,7 @@ impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {
 	///
 	/// Returns
 	/// * Ok(Some(old_element)) if the new element was added and an old element
-	///   had to removed.
+	///   had to be removed.
 	/// * Ok(None) if the element was added without removing an element.
 	/// * Err(true) if the set is full and the new element has a lower rank than
 	///   the lowest element in the set.

--- a/pallets/parachain-staking/src/tests.rs
+++ b/pallets/parachain-staking/src/tests.rs
@@ -315,7 +315,7 @@ fn join_collator_candidates() {
 			assert_ok!(StakePallet::join_candidates(Origin::signed(7), 10u128,));
 			assert_eq!(
 				last_event(),
-				MetaEvent::StakePallet(Event::JoinedCollatorCandidates(7, 10u128, 710u128))
+				MetaEvent::StakePallet(Event::JoinedCollatorCandidates(7, 10u128))
 			);
 
 			// MaxCollatorCandidateStake
@@ -331,11 +331,7 @@ fn join_collator_candidates() {
 
 			assert_eq!(
 				last_event(),
-				MetaEvent::StakePallet(Event::JoinedCollatorCandidates(
-					10,
-					StakePallet::max_candidate_stake(),
-					StakePallet::max_candidate_stake() + 710u128
-				))
+				MetaEvent::StakePallet(Event::JoinedCollatorCandidates(10, StakePallet::max_candidate_stake(),))
 			);
 		});
 }
@@ -359,8 +355,22 @@ fn collator_exit_executes_after_delay() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(CandidateCount::<Test>::get(), 3);
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 700,
+					delegators: 400
+				}
+			);
 			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
-			assert_eq!(Ok(StakePallet::selected_candidates()), vec![1, 2, 7].try_into());
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 800,
+					delegators: 400
+				}
+			);
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 7]);
 			roll_to(4, vec![]);
 			assert_noop!(
 				StakePallet::init_leave_candidates(Origin::signed(3)),
@@ -375,7 +385,7 @@ fn collator_exit_executes_after_delay() {
 				StakePallet::delegate_another_candidate(Origin::signed(3), 2, 10),
 				Error::<Test>::CannotDelegateIfLeaving
 			);
-			assert_eq!(Ok(StakePallet::selected_candidates()), vec![1, 7].try_into());
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 7]);
 			assert_eq!(
 				last_event(),
 				MetaEvent::StakePallet(Event::CollatorScheduledExit(2, 2, 4))
@@ -392,15 +402,10 @@ fn collator_exit_executes_after_delay() {
 			// (within the last T::StakeDuration blocks)
 			roll_to(25, vec![]);
 			let expected = vec![
-				Event::CollatorChosen(1, 500, 200),
-				Event::CollatorChosen(2, 200, 200),
-				Event::CollatorChosen(7, 100, 0),
 				Event::MaxSelectedCandidatesSet(2, 5),
 				Event::NewRound(5, 1),
 				Event::NewRound(10, 2),
 				Event::LeftTopCandidates(2),
-				Event::CollatorChosen(1, 500, 200),
-				Event::CollatorChosen(7, 100, 0),
 				Event::CollatorScheduledExit(2, 2, 4),
 				Event::NewRound(15, 3),
 				Event::NewRound(20, 4),
@@ -428,19 +433,26 @@ fn collator_selection_chooses_top_candidates() {
 		.with_collators(vec![(1, 100), (2, 90), (3, 80), (4, 70), (5, 60), (6, 50)])
 		.build()
 		.execute_with(|| {
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2]);
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 190,
+					delegators: 0
+				}
+			);
 			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 400,
+					delegators: 0
+				}
+			);
 			roll_to(8, vec![]);
 			// should choose top MaxSelectedCandidates (5), in order
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5]);
-			let expected = vec![
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
-				Event::CollatorChosen(5, 60, 0),
-				Event::MaxSelectedCandidatesSet(2, 5),
-				Event::NewRound(5, 1),
-			];
+			let expected = vec![Event::MaxSelectedCandidatesSet(2, 5), Event::NewRound(5, 1)];
 			assert_eq!(events(), expected);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(6)));
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5],);
@@ -451,31 +463,22 @@ fn collator_selection_chooses_top_candidates() {
 
 			roll_to(15, vec![]);
 			assert_ok!(StakePallet::execute_leave_candidates(Origin::signed(6), 6));
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5]);
 
 			roll_to(21, vec![]);
 			assert_ok!(StakePallet::join_candidates(Origin::signed(6), 69u128));
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 6]);
 			assert_eq!(
 				last_event(),
-				MetaEvent::StakePallet(Event::JoinedCollatorCandidates(6, 69u128, 409u128))
+				MetaEvent::StakePallet(Event::JoinedCollatorCandidates(6, 69u128))
 			);
 
 			roll_to(27, vec![]);
 			// should choose top MaxSelectedCandidates (5), in order
 			let expected = vec![
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
-				Event::CollatorChosen(5, 60, 0),
 				Event::MaxSelectedCandidatesSet(2, 5),
 				Event::NewRound(5, 1),
 				Event::LeftTopCandidates(6),
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
-				Event::CollatorChosen(5, 60, 0),
 				Event::CollatorScheduledExit(1, 6, 3),
 				// TotalStakeis updated once candidate 6 left in `execute_delayed_collator_exits`
 				Event::NewRound(10, 2),
@@ -483,12 +486,7 @@ fn collator_selection_chooses_top_candidates() {
 				Event::CollatorLeft(6, 50),
 				Event::NewRound(20, 4),
 				Event::EnteredTopCandidates(6),
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
-				Event::CollatorChosen(6, 69, 0),
-				Event::JoinedCollatorCandidates(6, 69, 409),
+				Event::JoinedCollatorCandidates(6, 69),
 				Event::NewRound(25, 5),
 			];
 			assert_eq!(events(), expected);
@@ -514,19 +512,14 @@ fn exit_queue_with_events() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(CandidateCount::<Test>::get(), 6);
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2]);
 			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5]);
+
 			roll_to(8, vec![]);
 			// should choose top MaxSelectedCandidates (5), in order
-			assert_eq!(Ok(StakePallet::selected_candidates()), vec![1, 2, 3, 4, 5].try_into());
-			let mut expected = vec![
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
-				Event::CollatorChosen(5, 60, 0),
-				Event::MaxSelectedCandidatesSet(2, 5),
-				Event::NewRound(5, 1),
-			];
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5]);
+			let mut expected = vec![Event::MaxSelectedCandidatesSet(2, 5), Event::NewRound(5, 1)];
 			assert_eq!(events(), expected);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(6)));
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5]);
@@ -543,7 +536,7 @@ fn exit_queue_with_events() {
 				MetaEvent::StakePallet(Event::CollatorScheduledExit(2, 5, 4))
 			);
 
-			assert_eq!(CandidateCount::<Test>::get(), 6, "No collators left.");
+			assert_eq!(CandidateCount::<Test>::get(), 6, "No collators have left yet.");
 			roll_to(16, vec![]);
 			assert_ok!(StakePallet::execute_leave_candidates(Origin::signed(6), 6));
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(4)));
@@ -557,37 +550,26 @@ fn exit_queue_with_events() {
 				Error::<Test>::AlreadyLeaving
 			);
 
-			assert_eq!(CandidateCount::<Test>::get(), 5, "collator left.");
+			assert_eq!(CandidateCount::<Test>::get(), 5, "Collator #5 left.");
 			roll_to(20, vec![]);
 			assert_ok!(StakePallet::execute_leave_candidates(Origin::signed(5), 5));
-			assert_eq!(CandidateCount::<Test>::get(), 4, "Two collators left.");
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3]);
+			assert_eq!(CandidateCount::<Test>::get(), 4, "Two out of six collators left.");
 
 			roll_to(26, vec![]);
 			assert_ok!(StakePallet::execute_leave_candidates(Origin::signed(4), 4));
-			assert_eq!(CandidateCount::<Test>::get(), 3, "three collators left.");
+			assert_eq!(CandidateCount::<Test>::get(), 3, "Three out of six collators left.");
 
 			roll_to(30, vec![]);
 			let mut new_events = vec![
 				Event::LeftTopCandidates(6),
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
-				Event::CollatorChosen(5, 60, 0),
 				Event::CollatorScheduledExit(1, 6, 3),
 				Event::NewRound(10, 2),
 				Event::LeftTopCandidates(5),
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
-				Event::CollatorChosen(4, 70, 0),
 				Event::CollatorScheduledExit(2, 5, 4),
 				Event::NewRound(15, 3),
 				Event::CollatorLeft(6, 50),
 				Event::LeftTopCandidates(4),
-				Event::CollatorChosen(1, 100, 0),
-				Event::CollatorChosen(2, 90, 0),
-				Event::CollatorChosen(3, 80, 0),
 				Event::CollatorScheduledExit(3, 4, 5),
 				Event::NewRound(20, 4),
 				Event::CollatorLeft(5, 60),
@@ -636,17 +618,24 @@ fn execute_leave_candidates_with_delay() {
 		.build()
 		.execute_with(|| {
 			assert_eq!(CandidateCount::<Test>::get(), 10);
-			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
-			roll_to(5, vec![]);
-			// should choose top MaxSelectedCandidates (5), in order
-			let mut old_stake = StakePallet::total_collator_stake();
 			assert_eq!(
-				old_stake,
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 30,
+					delegators: 500,
+				}
+			);
+			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
+			assert_eq!(
+				StakePallet::total_collator_stake(),
 				TotalStake {
 					collators: 300,
 					delegators: 500,
 				}
 			);
+
+			roll_to(5, vec![]);
+			// should choose top MaxSelectedCandidates (5), in order
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![2, 1, 10, 9, 8]);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(10)));
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(9)));
@@ -662,11 +651,11 @@ fn execute_leave_candidates_with_delay() {
 					.unwrap()
 					.can_exit(1 + <Test as Config>::ExitQueueDelay::get()));
 			}
-			old_stake = TotalStake {
+			let total_stake = TotalStake {
 				collators: 70,
 				delegators: 0,
 			};
-			assert_eq!(StakePallet::total_collator_stake(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), total_stake);
 			assert_eq!(
 				StakePallet::candidate_pool(1),
 				Some(
@@ -772,7 +761,7 @@ fn execute_leave_candidates_with_delay() {
 
 			// exits cannot be executed yet but in the next round
 			roll_to(10, vec![]);
-			assert_eq!(StakePallet::total_collator_stake(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), total_stake);
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![4, 3]);
 			for owner in vec![1, 2, 5, 6, 7, 8, 9, 10].iter() {
 				assert!(StakePallet::candidate_pool(owner)
@@ -783,7 +772,7 @@ fn execute_leave_candidates_with_delay() {
 					Error::<Test>::CannotLeaveYet
 				);
 			}
-			assert_eq!(StakePallet::total_collator_stake(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), total_stake);
 			assert_eq!(
 				StakePallet::candidate_pool(1),
 				Some(
@@ -889,7 +878,7 @@ fn execute_leave_candidates_with_delay() {
 
 			// execute first five exits are executed
 			roll_to(15, vec![]);
-			assert_eq!(StakePallet::total_collator_stake(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), total_stake);
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![4, 3]);
 			for collator in vec![1u64, 2u64, 5u64, 6u64, 7u64].iter() {
 				assert_ok!(StakePallet::execute_leave_candidates(
@@ -902,7 +891,7 @@ fn execute_leave_candidates_with_delay() {
 			}
 			assert_eq!(CandidateCount::<Test>::get(), 5, "Five collators left.");
 
-			assert_eq!(StakePallet::total_collator_stake(), old_stake);
+			assert_eq!(StakePallet::total_collator_stake(), total_stake);
 			for delegator in 11u64..=14u64 {
 				assert!(!StakePallet::is_delegator(&delegator));
 				assert_eq!(StakePallet::unstaking(delegator).len(), 1);
@@ -949,15 +938,7 @@ fn multiple_delegations() {
 			roll_to(8, vec![]);
 			// chooses top MaxSelectedCandidates (5), in order
 			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 3, 4, 5]);
-			let mut expected = vec![
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(2, 20, 20),
-				Event::CollatorChosen(3, 20, 0),
-				Event::CollatorChosen(4, 20, 0),
-				Event::CollatorChosen(5, 10, 0),
-				Event::MaxSelectedCandidatesSet(2, 5),
-				Event::NewRound(5, 1),
-			];
+			let mut expected = vec![Event::MaxSelectedCandidatesSet(2, 5), Event::NewRound(5, 1)];
 			assert_eq!(events(), expected);
 			assert_noop!(
 				StakePallet::delegate_another_candidate(Origin::signed(6), 1, 10),
@@ -977,24 +958,10 @@ fn multiple_delegations() {
 			);
 
 			roll_to(16, vec![]);
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 2, 4, 3, 5]);
 			let mut new = vec![
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(2, 20, 30),
-				Event::CollatorChosen(3, 20, 0),
-				Event::CollatorChosen(4, 20, 0),
-				Event::CollatorChosen(5, 10, 0),
 				Event::Delegation(6, 10, 2, 50),
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(2, 20, 30),
-				Event::CollatorChosen(4, 20, 10),
-				Event::CollatorChosen(3, 20, 0),
-				Event::CollatorChosen(5, 10, 0),
 				Event::Delegation(6, 10, 4, 30),
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(2, 20, 30),
-				Event::CollatorChosen(4, 20, 10),
-				Event::CollatorChosen(3, 20, 10),
-				Event::CollatorChosen(5, 10, 0),
 				Event::Delegation(6, 10, 3, 30),
 				Event::NewRound(10, 2),
 				Event::NewRound(15, 3),
@@ -1028,33 +995,20 @@ fn multiple_delegations() {
 				.contains(&StakeOf::<Test> { owner: 9, amount: 10 }));
 
 			roll_to(26, vec![]);
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![2, 1, 4, 3, 5]);
 			let mut new2 = vec![
 				Event::NewRound(20, 4),
-				Event::CollatorChosen(2, 20, 110),
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(4, 20, 10),
-				Event::CollatorChosen(3, 20, 10),
-				Event::CollatorChosen(5, 10, 0),
 				Event::Delegation(7, 80, 2, 130),
 				Event::DelegationReplaced(10, 11, 6, 10, 2, 131),
-				Event::CollatorChosen(2, 20, 111),
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(4, 20, 10),
-				Event::CollatorChosen(3, 20, 10),
-				Event::CollatorChosen(5, 10, 0),
 				Event::Delegation(10, 11, 2, 131),
 				Event::DelegationReplaced(11, 11, 9, 10, 2, 132),
-				Event::CollatorChosen(2, 20, 112),
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(4, 20, 10),
-				Event::CollatorChosen(3, 20, 10),
-				Event::CollatorChosen(5, 10, 0),
 				Event::Delegation(11, 11, 2, 132),
 				Event::NewRound(25, 5),
 			];
 			expected.append(&mut new2);
 			assert_eq!(events(), expected);
 			assert_ok!(StakePallet::init_leave_candidates(Origin::signed(2)));
+			assert_eq!(StakePallet::selected_candidates().into_inner(), vec![1, 4, 3, 5]);
 			assert_eq!(
 				last_event(),
 				MetaEvent::StakePallet(Event::CollatorScheduledExit(5, 2, 7))
@@ -1063,10 +1017,6 @@ fn multiple_delegations() {
 			roll_to(31, vec![]);
 			let mut new3 = vec![
 				Event::LeftTopCandidates(2),
-				Event::CollatorChosen(1, 20, 30),
-				Event::CollatorChosen(4, 20, 10),
-				Event::CollatorChosen(3, 20, 10),
-				Event::CollatorChosen(5, 10, 0),
 				Event::CollatorScheduledExit(5, 2, 7),
 				Event::NewRound(30, 6),
 			];
@@ -1144,6 +1094,13 @@ fn should_update_total_stake() {
 		.build()
 		.execute_with(|| {
 			let mut old_stake = StakePallet::total_collator_stake();
+			assert_eq!(
+				old_stake,
+				TotalStake {
+					collators: 40,
+					delegators: 30,
+				}
+			);
 			assert_ok!(StakePallet::candidate_stake_more(Origin::signed(1), 50));
 			assert_eq!(
 				StakePallet::total_collator_stake(),
@@ -2130,7 +2087,7 @@ fn should_end_session_when_appropriate() {
 }
 
 #[test]
-fn set_max_selected_candidates() {
+fn set_max_selected_candidates_safe_guards() {
 	ExtBuilder::default()
 		.with_balances(vec![(1, 10)])
 		.with_collators(vec![(1, 10)])
@@ -2140,10 +2097,87 @@ fn set_max_selected_candidates() {
 				StakePallet::set_max_selected_candidates(Origin::root(), <Test as Config>::MinCollators::get() - 1),
 				Error::<Test>::CannotSetBelowMin
 			);
+			assert_noop!(
+				StakePallet::set_max_selected_candidates(Origin::root(), <Test as Config>::MaxTopCandidates::get() + 1),
+				Error::<Test>::CannotSetAboveMax
+			);
 			assert_ok!(StakePallet::set_max_selected_candidates(
 				Origin::root(),
 				<Test as Config>::MinCollators::get() + 1
 			));
+		});
+}
+
+#[test]
+fn set_max_selected_candidates_total_stake() {
+	let balances: Vec<(AccountId, Balance)> = (1..19).map(|x| (x, 100)).collect();
+	ExtBuilder::default()
+		.with_balances(balances)
+		.with_collators(vec![
+			(1, 11),
+			(2, 12),
+			(3, 13),
+			(4, 14),
+			(5, 15),
+			(6, 16),
+			(7, 17),
+			(8, 18),
+		])
+		.with_delegators(vec![
+			(11, 1, 21),
+			(12, 2, 22),
+			(13, 3, 23),
+			(14, 4, 24),
+			(15, 5, 25),
+			(16, 6, 26),
+			(17, 7, 27),
+			(18, 8, 28),
+		])
+		.build()
+		.execute_with(|| {
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 35,
+					delegators: 55,
+				}
+			);
+
+			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 3));
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 51,
+					delegators: 81,
+				}
+			);
+
+			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 5));
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 80,
+					delegators: 130,
+				}
+			);
+
+			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 10));
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 116,
+					delegators: 196,
+				}
+			);
+
+			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 2));
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 35,
+					delegators: 55,
+				}
+			);
 		});
 }
 
@@ -2991,7 +3025,23 @@ fn force_remove_candidate() {
 
 			// force remove 1
 			assert!(Session::disabled_validators().is_empty());
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 200,
+					delegators: 150,
+				}
+			);
 			assert_ok!(StakePallet::force_remove_candidate(Origin::root(), 1));
+			// collator stake does not change since 3, who took 1's place, has staked the
+			// same amount
+			assert_eq!(
+				StakePallet::total_collator_stake(),
+				TotalStake {
+					collators: 200,
+					delegators: 50,
+				}
+			);
 			assert_eq!(Session::disabled_validators(), vec![0]);
 			assert_eq!(last_event(), MetaEvent::StakePallet(Event::CollatorRemoved(1, 200)));
 			assert!(!StakePallet::top_candidates().contains(&StakeOf::<Test> { owner: 1, amount: 100 }));
@@ -3362,7 +3412,7 @@ fn authorities_per_round() {
 			let reward_0 = inflation.collator.reward_rate.per_block * stake * 2;
 			assert_eq!(Balances::free_balance(1), stake + reward_0);
 			// increase max selected candidates which will become effective in round 2
-			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 20));
+			assert_ok!(StakePallet::set_max_selected_candidates(Origin::root(), 10));
 
 			// roll to last block of round 1
 			// should still multiply with 2 because the Authority set was chosen at start of

--- a/runtimes/peregrine/src/weights/parachain_staking.rs
+++ b/runtimes/peregrine/src/weights/parachain_staking.rs
@@ -139,12 +139,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking CandidateCount (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_candidates(n: u32, m: u32, ) -> Weight {
+	fn join_candidates() -> Weight {
 		(83_635_000 as Weight)
-			// Standard Error: 58_000
-			.saturating_add((4_079_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 213_000
-			.saturating_add((9_583_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(18 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
@@ -166,12 +162,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
+	fn cancel_leave_candidates() -> Weight {
 		(137_072_000 as Weight)
-			// Standard Error: 11_000
-			.saturating_add((2_550_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 31_000
-			.saturating_add((8_705_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(19 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
@@ -190,9 +182,7 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 			// Standard Error: 39_000
 			.saturating_add((28_966_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -202,12 +192,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn candidate_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 64_000
-			.saturating_add((4_847_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 237_000
-			.saturating_add((12_324_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 905_000
 			.saturating_add((6_229_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
@@ -218,12 +204,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
+	fn candidate_stake_less() -> Weight {
 		(0 as Weight)
-			// Standard Error: 70_000
-			.saturating_add((4_804_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 257_000
-			.saturating_add((12_130_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -237,12 +219,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_delegators(n: u32, m: u32, ) -> Weight {
+	fn join_delegators() -> Weight {
 		(38_983_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_884_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 284_000
-			.saturating_add((12_982_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(18 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 	}
@@ -254,12 +232,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn delegator_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 65_000
-			.saturating_add((4_805_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 273_000
-			.saturating_add((12_728_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 1_092_000
 			.saturating_add((7_634_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
@@ -271,12 +245,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
+	fn delegator_stake_less() -> Weight {
 		(5_521_000 as Weight)
-			// Standard Error: 72_000
-			.saturating_add((4_556_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 297_000
-			.saturating_add((12_025_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -286,12 +256,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
+	fn revoke_delegation( ) -> Weight {
 		(29_370_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_356_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 287_000
-			.saturating_add((11_536_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -301,12 +267,10 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn leave_delegators(n: u32, m: u32, ) -> Weight {
+	fn leave_delegators(n: u32, ) -> Weight {
 		(25_052_000 as Weight)
 			// Standard Error: 68_000
 			.saturating_add((4_397_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 283_000
-			.saturating_add((11_569_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}

--- a/runtimes/spiritnet/src/weights/parachain_staking.rs
+++ b/runtimes/spiritnet/src/weights/parachain_staking.rs
@@ -139,12 +139,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking CandidateCount (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_candidates(n: u32, m: u32, ) -> Weight {
+	fn join_candidates() -> Weight {
 		(83_635_000 as Weight)
-			// Standard Error: 58_000
-			.saturating_add((4_079_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 213_000
-			.saturating_add((9_583_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(18 as Weight))
 			.saturating_add(T::DbWeight::get().writes(7 as Weight))
 	}
@@ -166,12 +162,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn cancel_leave_candidates(n: u32, m: u32, ) -> Weight {
+	fn cancel_leave_candidates() -> Weight {
 		(137_072_000 as Weight)
-			// Standard Error: 11_000
-			.saturating_add((2_550_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 31_000
-			.saturating_add((8_705_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(19 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
@@ -190,9 +182,7 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 			// Standard Error: 39_000
 			.saturating_add((28_966_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
-			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(m as Weight)))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(m as Weight)))
 	}
 	// Storage: ParachainStaking CandidatePool (r:2 w:1)
 	// Storage: ParachainStaking MaxCollatorCandidateStake (r:1 w:0)
@@ -202,12 +192,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn candidate_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 64_000
-			.saturating_add((4_847_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 237_000
-			.saturating_add((12_324_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 905_000
 			.saturating_add((6_229_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
@@ -218,12 +204,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn candidate_stake_less(n: u32, m: u32, ) -> Weight {
+	fn candidate_stake_less() -> Weight {
 		(0 as Weight)
-			// Standard Error: 70_000
-			.saturating_add((4_804_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 257_000
-			.saturating_add((12_130_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -237,12 +219,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn join_delegators(n: u32, m: u32, ) -> Weight {
+	fn join_delegators() -> Weight {
 		(38_983_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_884_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 284_000
-			.saturating_add((12_982_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(18 as Weight))
 			.saturating_add(T::DbWeight::get().writes(8 as Weight))
 	}
@@ -254,12 +232,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_more(n: u32, m: u32, u: u32, ) -> Weight {
+	fn delegator_stake_more(u: u32, ) -> Weight {
 		(0 as Weight)
-			// Standard Error: 65_000
-			.saturating_add((4_805_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 273_000
-			.saturating_add((12_728_000 as Weight).saturating_mul(m as Weight))
 			// Standard Error: 1_092_000
 			.saturating_add((7_634_000 as Weight).saturating_mul(u as Weight))
 			.saturating_add(T::DbWeight::get().reads(12 as Weight))
@@ -271,12 +245,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn delegator_stake_less(n: u32, m: u32, ) -> Weight {
+	fn delegator_stake_less() -> Weight {
 		(5_521_000 as Weight)
-			// Standard Error: 72_000
-			.saturating_add((4_556_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 297_000
-			.saturating_add((12_025_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -286,12 +256,8 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn revoke_delegation(n: u32, m: u32, ) -> Weight {
+	fn revoke_delegation( ) -> Weight {
 		(29_370_000 as Weight)
-			// Standard Error: 69_000
-			.saturating_add((4_356_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 287_000
-			.saturating_add((11_536_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}
@@ -301,12 +267,10 @@ impl<T: frame_system::Config> parachain_staking::WeightInfo for WeightInfo<T> {
 	// Storage: ParachainStaking TopCandidates (r:1 w:1)
 	// Storage: ParachainStaking MaxSelectedCandidates (r:1 w:0)
 	// Storage: ParachainStaking TotalCollatorStake (r:1 w:1)
-	fn leave_delegators(n: u32, m: u32, ) -> Weight {
+	fn leave_delegators(n: u32, ) -> Weight {
 		(25_052_000 as Weight)
 			// Standard Error: 68_000
 			.saturating_add((4_397_000 as Weight).saturating_mul(n as Weight))
-			// Standard Error: 283_000
-			.saturating_add((11_569_000 as Weight).saturating_mul(m as Weight))
 			.saturating_add(T::DbWeight::get().reads(13 as Weight))
 			.saturating_add(T::DbWeight::get().writes(5 as Weight))
 	}


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1701
* Improves updating of `TotalCollatorStake` storage by removing the iteration over all selected candidates (except for `init_leave_candidate` and `force_remove_candidate`
* Updates documentation

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] This PR does not introduce new custom types
  - [ ] If not, I have opened a companion PR with the type changes in the [KILT types-definitions repository](https://github.com/KILTprotocol/type-definitions/pulls)
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
