### PR TITLE
feat: generic access controll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,6 @@ name = "attestation"
 version = "1.3.1"
 dependencies = [
  "ctype",
- "delegation",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,7 +378,6 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "runtime-common",
  "scale-info",
  "serde",
  "sp-core",
@@ -1419,7 +1418,6 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "runtime-common",
  "scale-info",
  "serde",
  "sp-core",
@@ -1831,6 +1829,7 @@ dependencies = [
 name = "delegation"
 version = "1.3.1"
 dependencies = [
+ "attestation",
  "bitflags",
  "ctype",
  "env_logger 0.8.4",
@@ -1841,7 +1840,6 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "runtime-common",
  "scale-info",
  "serde",
  "sp-core",
@@ -8538,6 +8536,7 @@ dependencies = [
 name = "runtime-common"
 version = "0.1.0"
 dependencies = [
+ "attestation",
  "frame-support",
  "frame-system",
  "pallet-authorship",

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -58,6 +58,7 @@ runtime-benchmarks = [
   "frame-benchmarking",
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
+  "kilt-support/runtime-benchmarks",
   "sp-core",
 ]
 std = [

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -15,7 +15,6 @@ substrate-wasm-builder-runner = {version = "3.0.0"}
 [dev-dependencies]
 ctype = {features = ["mock"], path = "../ctype"}
 kilt-support = {features = ["mock"], path = "../../support"}
-runtime-common = {default-features = false, path = "../../runtimes/common"}
 
 pallet-balances = {branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate"}
 serde = {version = "1.0.124"}
@@ -27,7 +26,6 @@ sp-keystore = {branch = "polkadot-v0.9.12", default-features = false, git = "htt
 # Internal dependencies
 ctype = {default-features = false, path = "../ctype"}
 kilt-support = {default-features = false, path = "../../support"}
-runtime-common = {default-features = false, optional = true, path = "../../runtimes/common"}
 
 #External dependencies
 codec = {default-features = false, features = ["derive"], package = "parity-scale-codec", version = "2.3.1"}
@@ -47,7 +45,6 @@ sp-std = {branch = "polkadot-v0.9.12", default-features = false, git = "https://
 [features]
 default = ["std"]
 mock = [
-  "runtime-common",
   "pallet-balances",
   "serde",
   "sp-core",
@@ -66,7 +63,6 @@ std = [
   "ctype/std",
   "frame-support/std",
   "frame-system/std",
-  "runtime-common/std",
   "kilt-support/std",
   "log/std",
   "pallet-balances/std",

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -14,7 +14,7 @@ substrate-wasm-builder-runner = {version = "3.0.0"}
 
 [dev-dependencies]
 ctype = {features = ["mock"], path = "../ctype"}
-delegation = {features = ["mock"], path = "../delegation"}
+kilt-support = {features = ["mock"], path = "../../support"}
 runtime-common = {default-features = false, path = "../../runtimes/common"}
 
 pallet-balances = {branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate"}
@@ -26,9 +26,8 @@ sp-keystore = {branch = "polkadot-v0.9.12", default-features = false, git = "htt
 [dependencies]
 # Internal dependencies
 ctype = {default-features = false, path = "../ctype"}
-delegation = {default-features = false, path = "../delegation"}
-runtime-common = {default-features = false, optional = true, path = "../../runtimes/common"}
 kilt-support = {default-features = false, path = "../../support"}
+runtime-common = {default-features = false, optional = true, path = "../../runtimes/common"}
 
 #External dependencies
 codec = {default-features = false, features = ["derive"], package = "parity-scale-codec", version = "2.3.1"}
@@ -37,7 +36,7 @@ frame-support = {branch = "polkadot-v0.9.12", default-features = false, git = "h
 frame-system = {branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate"}
 log = {default-features = false, version = "0.4.14"}
 pallet-balances = {optional = true, branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate"}
-scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+scale-info = {version = "1.0", default-features = false, features = ["derive"]}
 serde = {optional = true, version = "1.0.124"}
 sp-core = {branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
 sp-io = {branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate", optional = true}
@@ -56,7 +55,6 @@ mock = [
   "sp-keystore",
 ]
 runtime-benchmarks = [
-  "delegation/runtime-benchmarks",
   "frame-benchmarking",
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
@@ -65,7 +63,6 @@ runtime-benchmarks = [
 std = [
   "codec/std",
   "ctype/std",
-  "delegation/std",
   "frame-support/std",
   "frame-system/std",
   "runtime-common/std",

--- a/pallets/attestation/src/attestations.rs
+++ b/pallets/attestation/src/attestations.rs
@@ -18,11 +18,10 @@
 
 use codec::{Decode, Encode};
 use ctype::CtypeHashOf;
-use delegation::DelegationNodeIdOf;
 use kilt_support::deposit::Deposit;
 use scale_info::TypeInfo;
 
-use crate::{AccountIdOf, AttesterOf, BalanceOf, Config};
+use crate::{AccountIdOf, AttesterOf, AuthorizationIdOf, BalanceOf, Config};
 
 /// An on-chain attestation written by an attester.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo)]
@@ -34,7 +33,7 @@ pub struct AttestationDetails<T: Config> {
 	pub attester: AttesterOf<T>,
 	/// \[OPTIONAL\] The ID of the delegation node used to authorize the
 	/// attester.
-	pub delegation_id: Option<DelegationNodeIdOf<T>>,
+	pub authorization_id: Option<AuthorizationIdOf<T>>,
 	/// The flag indicating whether the attestation has been revoked or not.
 	pub revoked: bool,
 	/// The deposit that was taken to incentivise fair use of the on chain

--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -69,7 +69,7 @@ benchmarks! {
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), attester.clone());
 		Pallet::<T>::add(origin.clone(), claim_hash, ctype_hash, None)?;
-	}: _<T::Origin>(origin, claim_hash)
+	}: _<T::Origin>(origin, claim_hash, None)
 	verify {
 		assert!(Attestations::<T>::contains_key(claim_hash));
 		assert_eq!(Attestations::<T>::get(claim_hash), Some(AttestationDetails {
@@ -95,7 +95,7 @@ benchmarks! {
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), attester.clone());
 		Pallet::<T>::add(origin, claim_hash, ctype_hash, None)?;
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender, attester);
-	}: _<T::Origin>(origin, claim_hash)
+	}: _<T::Origin>(origin, claim_hash, None)
 	verify {
 		assert!(!Attestations::<T>::contains_key(claim_hash));
 	}

--- a/pallets/attestation/src/benchmarking.rs
+++ b/pallets/attestation/src/benchmarking.rs
@@ -19,12 +19,10 @@
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
 use frame_support::traits::{Currency, Get};
 use frame_system::RawOrigin;
-use sp_core::sr25519;
 use sp_runtime::traits::Hash;
 use sp_std::num::NonZeroU32;
 
-use delegation::{benchmarking::setup_delegations, Config as DelegationConfig, Permissions};
-use kilt_support::{signature::VerifySignature, traits::GenerateBenchmarkOrigin};
+use kilt_support::traits::GenerateBenchmarkOrigin;
 
 use crate::*;
 
@@ -35,33 +33,24 @@ benchmarks! {
 	where_clause {
 		where
 		T: core::fmt::Debug,
-		T::DelegationNodeId: From<T::Hash>,
-		T::CtypeCreatorId: From<T::DelegationEntityId>,
-		T::DelegationEntityId: From<sr25519::Public>,
-		<<T as delegation::Config>::DelegationSignatureVerification as VerifySignature>::Signature: From<(
-			T::DelegationEntityId,
-			<<T as delegation::Config>::DelegationSignatureVerification as VerifySignature>::Payload,
-		)>,
-		<T as Config>::EnsureOrigin: GenerateBenchmarkOrigin<T::Origin, T::AccountId, T::DelegationEntityId>,
-		<T as DelegationConfig>::EnsureOrigin: GenerateBenchmarkOrigin<T::Origin, T::AccountId, T::DelegationEntityId>,
+		<T as Config>::EnsureOrigin: GenerateBenchmarkOrigin<T::Origin, T::AccountId, T::AttesterId>,
 	}
 
 	add {
 		let sender: T::AccountId = account("sender", 0, SEED);
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
-		let (_, _, delegate_public, delegation_id) = setup_delegations::<T>(1, ONE_CHILD_PER_LEVEL.expect(">0"), Permissions::ATTEST)?;
-		let delegate_acc: T::DelegationEntityId = delegate_public.into();
+
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), delegate_acc.clone());
-	}: _<T::Origin>(origin, claim_hash, ctype_hash, Some(delegation_id))
+	}: _<T::Origin>(origin, claim_hash, ctype_hash, Some(attestation_id))
 	verify {
 		assert!(Attestations::<T>::contains_key(claim_hash));
 		assert_eq!(Pallet::<T>::attestations(claim_hash), Some(AttestationDetails {
 			ctype_hash,
 			attester: delegate_acc,
-			delegation_id: Some(delegation_id),
+			attestation_id: Some(attestation_id),
 			revoked: false,
 			deposit: kilt_support::deposit::Deposit {
 				owner: sender,
@@ -77,14 +66,11 @@ benchmarks! {
 		let claim_hash: T::Hash = T::Hashing::hash(b"claim");
 		let ctype_hash: T::Hash = T::Hash::default();
 
-		let (root_public, _, delegate_public, delegation_id) = setup_delegations::<T>(d, ONE_CHILD_PER_LEVEL.expect(">0"), Permissions::ATTEST | Permissions::DELEGATE)?;
-		let root_acc: T::DelegationEntityId = root_public.into();
-		let delegate_acc: T::DelegationEntityId = delegate_public.into();
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		// attest with leaf account
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), delegate_acc.clone());
-		Pallet::<T>::add(origin, claim_hash, ctype_hash, Some(delegation_id))?;
+		Pallet::<T>::add(origin, claim_hash, ctype_hash, Some(attestation_id))?;
 		// revoke with root account, s.t. delegation tree needs to be traversed
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), root_acc);
 	}: _<T::Origin>(origin, claim_hash, d)
@@ -93,7 +79,7 @@ benchmarks! {
 		assert_eq!(Attestations::<T>::get(claim_hash), Some(AttestationDetails {
 			ctype_hash,
 			attester: delegate_acc,
-			delegation_id: Some(delegation_id),
+			attestation_id: Some(attestation_id),
 			revoked: true,
 			deposit: kilt_support::deposit::Deposit {
 				owner: sender,
@@ -109,14 +95,11 @@ benchmarks! {
 		let ctype_hash: T::Hash = T::Hash::default();
 
 		let sender: T::AccountId = account("sender", 0, SEED);
-		let (root_public, _, delegate_public, delegation_id) = setup_delegations::<T>(d, ONE_CHILD_PER_LEVEL.expect(">0"), Permissions::ATTEST | Permissions::DELEGATE)?;
-		let root_acc: T::DelegationEntityId = root_public.into();
-		let delegate_acc: T::DelegationEntityId = delegate_public.into();
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		// attest with leaf account
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), delegate_acc);
-		Pallet::<T>::add(origin, claim_hash, ctype_hash, Some(delegation_id))?;
+		Pallet::<T>::add(origin, claim_hash, ctype_hash, Some(attestation_id))?;
 		// revoke with root account, s.t. delegation tree needs to be traversed
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender, root_acc);
 	}: _<T::Origin>(origin, claim_hash, d)
@@ -129,14 +112,11 @@ benchmarks! {
 		let ctype_hash: T::Hash = T::Hash::default();
 
 		let sender: T::AccountId = account("sender", 0, SEED);
-		let (root_public, _, delegate_public, delegation_id) = setup_delegations::<T>(1, ONE_CHILD_PER_LEVEL.expect(">0"), Permissions::ATTEST | Permissions::DELEGATE)?;
-		let root_acc: T::DelegationEntityId = root_public.into();
-		let delegate_acc: T::DelegationEntityId = delegate_public.into();
 		<T as Config>::Currency::make_free_balance_be(&sender, <T as Config>::Deposit::get() + <T as Config>::Deposit::get());
 
 		// attest with leaf account
 		let origin = <T as Config>::EnsureOrigin::generate_origin(sender.clone(), delegate_acc);
-		Pallet::<T>::add(origin, claim_hash, ctype_hash, Some(delegation_id))?;
+		Pallet::<T>::add(origin, claim_hash, ctype_hash, Some(attestation_id))?;
 		// revoke with root account, s.t. delegation tree needs to be traversed
 		let origin = RawOrigin::Signed(sender);
 	}: _(origin, claim_hash)

--- a/pallets/attestation/src/default_weights.rs
+++ b/pallets/attestation/src/default_weights.rs
@@ -47,8 +47,8 @@ use sp_std::marker::PhantomData;
 /// Weight functions needed for attestation.
 pub trait WeightInfo {
 	fn add() -> Weight;
-	fn revoke(d: u32, ) -> Weight;
-	fn remove(d: u32, ) -> Weight;
+	fn revoke() -> Weight;
+	fn remove() -> Weight;
 	fn reclaim_deposit() -> Weight;
 }
 
@@ -60,20 +60,20 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	fn revoke(d: u32, ) -> Weight {
+	fn revoke() -> Weight {
 		(37_029_000_u64)
 			// Standard Error: 44_000
-			.saturating_add((6_325_000_u64).saturating_mul(d as Weight))
+			.saturating_add(6_325_000_u64)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	fn remove(d: u32, ) -> Weight {
+	fn remove() -> Weight {
 		(64_058_000_u64)
 			// Standard Error: 44_000
-			.saturating_add((6_317_000_u64).saturating_mul(d as Weight))
+			.saturating_add(6_317_000_u64)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	fn reclaim_deposit() -> Weight {
@@ -90,20 +90,20 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(6_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
-	fn revoke(d: u32, ) -> Weight {
+	fn revoke() -> Weight {
 		(37_029_000_u64)
 			// Standard Error: 44_000
-			.saturating_add((6_325_000_u64).saturating_mul(d as Weight))
+			.saturating_add(6_325_000_u64)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
-			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
-	fn remove(d: u32, ) -> Weight {
+	fn remove() -> Weight {
 		(64_058_000_u64)
 			// Standard Error: 44_000
-			.saturating_add((6_317_000_u64).saturating_mul(d as Weight))
+			.saturating_add(6_317_000_u64)
 			.saturating_add(RocksDbWeight::get().reads(4_u64))
-			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}
 	fn reclaim_deposit() -> Weight {

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -97,7 +97,6 @@ pub mod pallet {
 		BoundedVec,
 	};
 	use frame_system::pallet_prelude::*;
-	use sp_runtime::traits::Zero;
 	use sp_runtime::DispatchError;
 
 	use ctype::CtypeHashOf;
@@ -111,13 +110,13 @@ pub mod pallet {
 
 	impl<T: Config> AttestationAccessControl<T> for () {
 		fn can_attest(_who: &T::AttesterId, _authorization_id: &T::AuthorizationId) -> Result<Weight, DispatchError> {
-			Ok(Weight::zero())
+			Err(DispatchError::Other("Unimplemented"))
 		}
 		fn can_revoke(_who: &T::AttesterId, _attestation: &AttestationDetails<T>) -> Result<Weight, DispatchError> {
-			Ok(Weight::zero())
+			Err(DispatchError::Other("Unimplemented"))
 		}
 		fn can_remove(_who: &T::AttesterId, _attestation: &AttestationDetails<T>) -> Result<Weight, DispatchError> {
-			Ok(Weight::zero())
+			Err(DispatchError::Other("Unimplemented"))
 		}
 	}
 
@@ -147,7 +146,7 @@ pub mod pallet {
 		type WeightInfo: WeightInfo;
 
 		/// The currency that is used to reserve funds for each attestation.
-		type Currency: Currency<AccountIdOf<Self>> + ReservableCurrency<AccountIdOf<Self>>;
+		type Currency: ReservableCurrency<AccountIdOf<Self>>;
 
 		/// The deposit that is required for storing an attestation.
 		#[pallet::constant]

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -102,39 +102,28 @@ pub mod pallet {
 	use ctype::CtypeHashOf;
 	use kilt_support::{deposit::Deposit, traits::CallSources};
 
-	pub trait AttestationAccessControl<T: Config> {
-		fn can_attest(&self, who: &T::AttesterId) -> Result<Weight, DispatchError>;
-		fn can_revoke(&self, who: &T::AttesterId, attestation: &AttestationDetails<T>)
-			-> Result<Weight, DispatchError>;
-		fn can_remove(&self, who: &T::AttesterId, attestation: &AttestationDetails<T>)
-			-> Result<Weight, DispatchError>;
-		fn authorization_id(&self) -> T::AuthorizationId;
+	pub trait AttestationAccessControl<AttesterId, AuthorizationId, T: Config> {
+		fn can_attest(&self, who: &AttesterId) -> Result<Weight, DispatchError>;
+		fn can_revoke(&self, who: &AttesterId, attestation: &AttestationDetails<T>) -> Result<Weight, DispatchError>;
+		fn can_remove(&self, who: &AttesterId, attestation: &AttestationDetails<T>) -> Result<Weight, DispatchError>;
+		fn authorization_id(&self) -> AuthorizationId;
 		fn weight(&self) -> Weight;
 	}
 
-	impl<T> AttestationAccessControl<T> for ()
+	impl<AttesterId, AuthorizationId, T: Config> AttestationAccessControl<AttesterId, AuthorizationId, T> for ()
 	where
-		T: Config,
-		T::AuthorizationId: Default,
+		AuthorizationId: Default,
 	{
-		fn can_attest(&self, _who: &T::AttesterId) -> Result<Weight, DispatchError> {
+		fn can_attest(&self, _who: &AttesterId) -> Result<Weight, DispatchError> {
 			Err(DispatchError::Other("Unimplemented"))
 		}
-		fn can_revoke(
-			&self,
-			_who: &T::AttesterId,
-			_attestation: &AttestationDetails<T>,
-		) -> Result<Weight, DispatchError> {
+		fn can_revoke(&self, _who: &AttesterId, _attestation: &AttestationDetails<T>) -> Result<Weight, DispatchError> {
 			Err(DispatchError::Other("Unimplemented"))
 		}
-		fn can_remove(
-			&self,
-			_who: &T::AttesterId,
-			_attestation: &AttestationDetails<T>,
-		) -> Result<Weight, DispatchError> {
+		fn can_remove(&self, _who: &AttesterId, _attestation: &AttestationDetails<T>) -> Result<Weight, DispatchError> {
 			Err(DispatchError::Other("Unimplemented"))
 		}
-		fn authorization_id(&self) -> T::AuthorizationId {
+		fn authorization_id(&self) -> AuthorizationId {
 			Default::default()
 		}
 		fn weight(&self) -> Weight {
@@ -183,7 +172,7 @@ pub mod pallet {
 
 		type AuthorizationId: Parameter;
 
-		type AccessControl: Parameter + AttestationAccessControl<Self>;
+		type AccessControl: Parameter + AttestationAccessControl<Self::AttesterId, Self::AuthorizationId, Self>;
 	}
 
 	#[pallet::pallet]

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -109,6 +109,7 @@ pub mod pallet {
 		fn can_remove(&self, who: &T::AttesterId, attestation: &AttestationDetails<T>)
 			-> Result<Weight, DispatchError>;
 		fn authorization_id(&self) -> T::AuthorizationId;
+		fn weight(&self) -> Weight;
 	}
 
 	impl<T> AttestationAccessControl<T> for ()
@@ -135,6 +136,9 @@ pub mod pallet {
 		}
 		fn authorization_id(&self) -> T::AuthorizationId {
 			Default::default()
+		}
+		fn weight(&self) -> Weight {
+			0
 		}
 	}
 

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -108,6 +108,10 @@ where
 	fn authorization_id(&self) -> T::AuthorizationId {
 		self.0.clone()
 	}
+
+	fn weight(&self) -> Weight {
+		0
+	}
 }
 
 /// Mocks that are only used internally

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -77,7 +77,7 @@ where
 #[derive(Clone, Debug, Encode, Decode, TypeInfo, PartialEq, Eq)]
 #[scale_info(skip_type_params(T))]
 pub struct MockAccessControl<T: Config>(pub T::AttesterId);
-impl<T: Config> AttestationAccessControl<T> for MockAccessControl<T>
+impl<T> AttestationAccessControl<T::AttesterId, T::AuthorizationId, T> for MockAccessControl<T>
 where
 	T: Config<AuthorizationId = <T as Config>::AttesterId>,
 {

--- a/pallets/attestation/src/tests.rs
+++ b/pallets/attestation/src/tests.rs
@@ -19,21 +19,19 @@
 use frame_support::{assert_noop, assert_ok};
 use sp_runtime::traits::Zero;
 
-use ctype::mock as ctype_mock;
-use delegation::mock::{self as delegation_mock, DELEGATION_ID_SEED_1, DELEGATION_ID_SEED_2};
 use kilt_support::mock::mock_origin::DoubleOrigin;
 
 use crate::{
 	self as attestation,
 	mock::{runtime::Balances, *},
-	AttesterOf, Config, DelegatedAttestations,
+	AttesterOf, Config,
 };
 
 // #############################################################################
-// submit_attestation_creation_operation
+// add
 
 #[test]
-fn attest_no_delegation_successful() {
+fn test_attest_successful() {
 	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 	let attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
@@ -47,75 +45,27 @@ fn attest_no_delegation_successful() {
 		.execute_with(|| {
 			assert_ok!(Attestation::add(
 				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-				operation.claim_hash,
+				claim_hash,
 				operation.ctype_hash,
-				operation.delegation_id
+				operation.authorization_id
 			));
 			let stored_attestation =
 				Attestation::attestations(&claim_hash).expect("Attestation should be present on chain.");
 
 			assert_eq!(stored_attestation.ctype_hash, operation.ctype_hash);
 			assert_eq!(stored_attestation.attester, attester);
-			assert_eq!(stored_attestation.delegation_id, operation.delegation_id);
+			assert_eq!(stored_attestation.authorization_id, operation.authorization_id);
 			assert!(!stored_attestation.revoked);
 		});
 }
 
 #[test]
-fn attest_with_delegation_successful() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details();
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Attestation::add(
-				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-				operation.claim_hash,
-				operation.ctype_hash,
-				operation.delegation_id
-			));
-			let stored_attestation =
-				Attestation::attestations(&claim_hash).expect("Attestation should be present on chain.");
-
-			assert_eq!(stored_attestation.ctype_hash, operation.ctype_hash);
-			assert_eq!(stored_attestation.attester, attester);
-			assert_eq!(stored_attestation.delegation_id, operation.delegation_id);
-			assert!(!stored_attestation.revoked);
-
-			let delegated_attestations = Attestation::delegated_attestations(&delegation_id)
-				.expect("Attested delegation should be present on chain.");
-
-			assert_eq!(delegated_attestations, vec![claim_hash]);
-		});
+fn test_attest_with_authorization_successful() {
+	todo!()
 }
 
 #[test]
-fn ctype_not_present_attest_error() {
+fn test_attest_ctype_not_found() {
 	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 	let attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
@@ -129,9 +79,9 @@ fn ctype_not_present_attest_error() {
 			assert_noop!(
 				Attestation::add(
 					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
+					claim_hash,
 					operation.ctype_hash,
-					operation.delegation_id
+					operation.authorization_id
 				),
 				ctype::Error::<Test>::CTypeNotFound
 			);
@@ -139,7 +89,7 @@ fn ctype_not_present_attest_error() {
 }
 
 #[test]
-fn duplicate_attest_error() {
+fn test_attest_already_exists() {
 	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 
@@ -155,9 +105,9 @@ fn duplicate_attest_error() {
 			assert_noop!(
 				Attestation::add(
 					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
+					claim_hash,
 					operation.ctype_hash,
-					operation.delegation_id
+					operation.authorization_id
 				),
 				attestation::Error::<Test>::AlreadyAttested
 			);
@@ -165,276 +115,28 @@ fn duplicate_attest_error() {
 }
 
 #[test]
-fn delegation_not_found_attest_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let claim_hash = get_claim_hash(true);
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::add(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.ctype_hash,
-					operation.delegation_id
-				),
-				delegation::Error::<Test>::DelegationNotFound
-			);
-		});
-}
-
-#[test]
-fn delegation_revoked_attest_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let claim_hash = get_claim_hash(true);
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	// Delegation node does not have permissions to attest.
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	delegation_node.details.revoked = true;
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::add(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.ctype_hash,
-					operation.delegation_id
-				),
-				attestation::Error::<Test>::DelegationRevoked
-			);
-		});
-}
-
-#[test]
-fn not_delegation_owner_attest_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let alternative_owner = sr25519_did_from_seed(&BOB_SEED);
-
-	let claim_hash = get_claim_hash(true);
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node::<Test>(
-		hierarchy_root_id,
-		alternative_owner,
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::add(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.ctype_hash,
-					operation.delegation_id
-				),
-				attestation::Error::<Test>::NotDelegatedToAttester
-			);
-		});
-}
-
-#[test]
-fn unauthorised_permissions_attest_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let claim_hash = get_claim_hash(true);
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	// Delegation node does not have permissions to attest.
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::add(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.ctype_hash,
-					operation.delegation_id
-				),
-				attestation::Error::<Test>::DelegationUnauthorizedToAttest
-			);
-		});
-}
-
-#[test]
-fn root_not_present_attest_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let claim_hash = get_claim_hash(true);
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let alternative_hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(false);
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(alternative_hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			alternative_hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::add(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.ctype_hash,
-					operation.delegation_id
-				),
-				delegation::Error::<Test>::HierarchyNotFound
-			);
-		});
-}
-
-#[test]
-fn root_ctype_mismatch_attest_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let claim_hash = get_claim_hash(true);
-	let alternative_ctype_hash = ctype_mock::get_ctype_hash::<Test>(false);
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let mut hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	hierarchy_details.ctype_hash = alternative_ctype_hash;
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	let mut attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_creation_details(claim_hash, attestation);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(operation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::add(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.ctype_hash,
-					operation.delegation_id
-				),
-				attestation::Error::<Test>::CTypeMismatch
-			);
-		});
+fn test_attest_unauthorized() {
+	todo!()
 }
 
 // #############################################################################
-// submit_attestation_revocation_operation
+// revoke
 
 #[test]
-fn revoke_and_remove_direct_successful() {
+fn test_revoke() {
 	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 	let attestation = generate_base_attestation::<Test>(revoker.clone(), ACCOUNT_00);
 
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
 		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
+		.with_attestations(vec![(claim_hash, attestation)])
 		.build()
 		.execute_with(|| {
 			assert_ok!(Attestation::revoke(
 				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
+				claim_hash,
 			));
 			let stored_attestation =
 				Attestation::attestations(claim_hash).expect("Attestation should be present on chain.");
@@ -444,8 +146,7 @@ fn revoke_and_remove_direct_successful() {
 
 			assert_ok!(Attestation::remove(
 				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
+				claim_hash,
 			));
 			assert!(Attestation::attestations(claim_hash).is_none());
 			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
@@ -453,248 +154,21 @@ fn revoke_and_remove_direct_successful() {
 }
 
 #[test]
-fn revoke_with_delegation_successful() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		revoker.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	// Attestation owned by a different user, but delegation owned by the user
-	// submitting the operation.
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let mut operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-	// Set to 0 as we only need to check the delegation node itself and no parent.
-	operation.max_parent_checks = 0u32;
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			revoker.clone(),
-			ACCOUNT_01,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Attestation::revoke(
-				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
-			));
-			let stored_attestation =
-				Attestation::attestations(operation.claim_hash).expect("Attestation should be present on chain.");
-
-			assert!(stored_attestation.revoked);
-		});
+fn test_authorized_revoke() {
+	todo!()
 }
 
 #[test]
-fn revoke_with_parent_delegation_successful() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let parent_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut parent_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		revoker.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	parent_node.details.permissions = delegation::Permissions::ATTEST;
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_2);
-	let delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attestation_owner.clone(),
-		Some(parent_id),
-		ACCOUNT_00,
-	);
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let mut operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-	// Set to 1 as the delegation referenced in the attestation is the child of the
-	// node we want to use
-	operation.max_parent_checks = 1u32;
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			revoker.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(parent_id, parent_node), (delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Attestation::revoke(
-				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
-			));
-			let stored_attestation =
-				Attestation::attestations(claim_hash).expect("Attestation should be present on chain.");
-
-			assert!(stored_attestation.revoked);
-		});
+fn test_unauthorized_revoke() {
+	todo!()
 }
 
 #[test]
-fn revoke_parent_delegation_no_attestation_permissions_successful() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let parent_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut parent_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		revoker.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	parent_node.details.permissions = delegation::Permissions::DELEGATE;
-
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_2);
-	let delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attestation_owner.clone(),
-		Some(parent_id),
-		ACCOUNT_00,
-	);
-
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let mut operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-	// Set to 1 as the delegation referenced in the attestation is the child of the
-	// node we want to use
-	operation.max_parent_checks = 1u32;
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			revoker.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(parent_id, parent_node), (delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Attestation::revoke(
-				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
-			));
-			let stored_attestation =
-				Attestation::attestations(claim_hash).expect("Attestation should be present on chain.");
-
-			assert!(stored_attestation.revoked);
-		});
-}
-
-#[test]
-fn revoke_parent_delegation_with_direct_delegation_revoked_successful() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let parent_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut parent_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		revoker.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	parent_node.details.permissions = delegation::Permissions::ATTEST;
-
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_2);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attestation_owner.clone(),
-		Some(parent_id),
-		ACCOUNT_00,
-	);
-
-	delegation_node.details.revoked = true;
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let mut operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-	// Set to 1 as the delegation referenced in the attestation is the child of the
-	// node we want to use
-	operation.max_parent_checks = 1u32;
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			revoker.clone(),
-			ACCOUNT_01,
-		)])
-		.with_delegations(vec![(parent_id, parent_node), (delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_ok!(Attestation::revoke(
-				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
-			));
-			let stored_attestation =
-				Attestation::attestations(claim_hash).expect("Attestation should be present on chain.");
-
-			assert!(stored_attestation.revoked);
-		});
-}
-
-#[test]
-fn attestation_not_present_revoke_error() {
+fn test_revoke_not_found() {
 	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 
 	let attestation = generate_base_attestation::<Test>(revoker.clone(), ACCOUNT_00);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
 
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
@@ -702,18 +176,14 @@ fn attestation_not_present_revoke_error() {
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				Attestation::revoke(
-					DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
+				Attestation::revoke(DoubleOrigin(ACCOUNT_00, revoker.clone()).into(), claim_hash,),
 				attestation::Error::<Test>::AttestationNotFound
 			);
 		});
 }
 
 #[test]
-fn already_revoked_revoke_error() {
+fn test_already_revoked() {
 	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 
@@ -721,158 +191,15 @@ fn already_revoked_revoke_error() {
 	let mut attestation = generate_base_attestation::<Test>(revoker.clone(), ACCOUNT_00);
 	attestation.revoked = true;
 
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
 		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
+		.with_attestations(vec![(claim_hash, attestation)])
 		.build()
 		.execute_with(|| {
 			assert_noop!(
-				Attestation::revoke(
-					DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
+				Attestation::revoke(DoubleOrigin(ACCOUNT_00, revoker.clone()).into(), claim_hash,),
 				attestation::Error::<Test>::AlreadyRevoked
-			);
-		});
-}
-
-#[test]
-fn unauthorised_attestation_revoke_error() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	// Attestation owned by a different user
-	let attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::revoke(
-					DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
-				attestation::Error::<Test>::Unauthorized
-			);
-		});
-}
-
-#[test]
-fn max_parent_lookups_revoke_error() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let parent_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let parent_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		revoker.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_2);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attestation_owner.clone(),
-		Some(parent_id),
-		ACCOUNT_00,
-	);
-
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let mut operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-	operation.max_parent_checks = 0u32;
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			revoker.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(parent_id, parent_node), (delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::revoke(
-					DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
-				delegation::Error::<Test>::MaxSearchDepthReached
-			);
-		});
-}
-
-#[test]
-fn revoked_delegation_revoke_error() {
-	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		revoker.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_00,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	delegation_node.details.revoked = true;
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			revoker.clone(),
-			ACCOUNT_00,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::revoke(
-					DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
-				attestation::Error::<Test>::Unauthorized
 			);
 		});
 }
@@ -881,116 +208,42 @@ fn revoked_delegation_revoke_error() {
 // remove attestation
 
 #[test]
-fn subject_remove_direct_successful() {
+fn test_remove() {
 	let revoker: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 	let attestation = generate_base_attestation::<Test>(revoker.clone(), ACCOUNT_00);
 
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
 		.with_ctypes(vec![(attestation.ctype_hash, revoker.clone())])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
+		.with_attestations(vec![(claim_hash, attestation)])
 		.build()
 		.execute_with(|| {
 			assert_ok!(Attestation::remove(
 				DoubleOrigin(ACCOUNT_00, revoker.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
+				claim_hash,
 			));
 			assert!(Attestation::attestations(claim_hash).is_none())
 		});
 }
 
 #[test]
-fn reclaim_deposit() {
-	let deposit_owner: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-	let attestation = generate_base_attestation::<Test>(attester, ACCOUNT_00);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
-	ExtBuilder::default()
-		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
-		.with_ctypes(vec![(attestation.ctype_hash, deposit_owner)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_noop!(
-				Attestation::reclaim_deposit(Origin::signed(ACCOUNT_01), operation.claim_hash),
-				attestation::Error::<Test>::Unauthorized,
-			);
-			assert_ok!(Attestation::reclaim_deposit(
-				Origin::signed(ACCOUNT_00),
-				operation.claim_hash,
-			));
-			assert!(Attestation::attestations(claim_hash).is_none())
-		});
+fn test_authorized_remove() {
+	todo!()
 }
 
 #[test]
-fn remove_with_delegation_successful() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details::<Test>();
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_01,
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	// Attestation owned by a different user, but delegation owned by the user
-	// submitting the operation.
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let mut operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-	// Set to 0 as we only need to check the delegation node itself and no parent.
-	operation.max_parent_checks = 0u32;
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_01,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Balances::reserved_balance(ACCOUNT_00), <Test as Config>::Deposit::get());
-			assert_ok!(Attestation::remove(
-				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
-			));
-			assert!(Attestation::attestations(operation.claim_hash).is_none());
-			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
-		});
+fn test_unauthorised_remove() {
+	todo!()
 }
 
 #[test]
-fn attestation_not_present_remove_error() {
+fn test_remove_not_found() {
 	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
 	let claim_hash = get_claim_hash(true);
 
 	let attestation = generate_base_attestation::<Test>(attester.clone(), ACCOUNT_00);
 
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
 	ExtBuilder::default()
 		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
 		.with_ctypes(vec![(attestation.ctype_hash, attester.clone())])
@@ -999,163 +252,39 @@ fn attestation_not_present_remove_error() {
 			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
 
 			assert_noop!(
-				Attestation::remove(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
+				Attestation::remove(DoubleOrigin(ACCOUNT_00, attester.clone()).into(), claim_hash,),
 				attestation::Error::<Test>::AttestationNotFound
 			);
 			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
 		});
 }
 
+// #############################################################################
+// reclaim deposit
+
 #[test]
-fn unauthorised_attestation_remove_error() {
-	let remover: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
+fn test_reclaim_deposit() {
+	let deposit_owner: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
+	let attester: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
 	let claim_hash = get_claim_hash(true);
-
-	// Attestation owned by a different user
-	let attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
+	let attestation = generate_base_attestation::<Test>(attester, ACCOUNT_00);
 
 	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01.clone(), <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, remover.clone())])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
+		.with_balances(vec![(ACCOUNT_00, <Test as Config>::Deposit::get() * 100)])
+		.with_ctypes(vec![(attestation.ctype_hash, deposit_owner)])
+		.with_attestations(vec![(claim_hash, attestation)])
 		.build()
 		.execute_with(|| {
-			assert_eq!(Balances::reserved_balance(ACCOUNT_00), <Test as Config>::Deposit::get());
 			assert_noop!(
-				Attestation::remove(
-					DoubleOrigin(ACCOUNT_00, remover.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
-				attestation::Error::<Test>::Unauthorized
+				Attestation::reclaim_deposit(Origin::signed(ACCOUNT_01), claim_hash),
+				attestation::Error::<Test>::Unauthorized,
 			);
-			assert_eq!(Balances::reserved_balance(ACCOUNT_00), <Test as Config>::Deposit::get());
+			assert_ok!(Attestation::reclaim_deposit(Origin::signed(ACCOUNT_00), claim_hash,));
+			assert!(Attestation::attestations(claim_hash).is_none())
 		});
 }
 
 #[test]
-fn revoked_delegation_remove_error() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details();
-
-	let delegation_id = delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1);
-	let mut delegation_node = delegation_mock::generate_base_delegation_node(
-		hierarchy_root_id,
-		attester.clone(),
-		Some(hierarchy_root_id),
-		ACCOUNT_01,
-	);
-
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	delegation_node.details.revoked = true;
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01.clone(), <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_01,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Balances::reserved_balance(ACCOUNT_00), <Test as Config>::Deposit::get());
-			assert_noop!(
-				Attestation::remove(
-					DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-					operation.claim_hash,
-					operation.max_parent_checks
-				),
-				attestation::Error::<Test>::Unauthorized
-			);
-			assert_eq!(Balances::reserved_balance(ACCOUNT_00), <Test as Config>::Deposit::get());
-		});
-}
-
-#[test]
-fn remove_delegated_attestation() {
-	let attester: AttesterOf<Test> = sr25519_did_from_seed(&ALICE_SEED);
-	let attestation_owner: AttesterOf<Test> = sr25519_did_from_seed(&BOB_SEED);
-	let claim_hash = get_claim_hash(true);
-
-	let hierarchy_root_id = delegation_mock::get_delegation_hierarchy_id::<Test>(true);
-	let hierarchy_details = delegation_mock::generate_base_delegation_hierarchy_details();
-	let (delegation_id, mut delegation_node) = (
-		delegation_mock::delegation_id_from_seed::<Test>(DELEGATION_ID_SEED_1),
-		delegation_mock::generate_base_delegation_node(
-			hierarchy_root_id,
-			attester.clone(),
-			Some(hierarchy_root_id),
-			ACCOUNT_01,
-		),
-	);
-	delegation_node.details.permissions = delegation::Permissions::ATTEST;
-	let mut attestation = generate_base_attestation::<Test>(attestation_owner, ACCOUNT_00);
-	attestation.delegation_id = Some(delegation_id);
-
-	let operation = generate_base_attestation_revocation_details::<Test>(claim_hash);
-
-	ExtBuilder::default()
-		.with_balances(vec![
-			(ACCOUNT_00, <Test as Config>::Deposit::get() * 100),
-			(ACCOUNT_01, <Test as Config>::Deposit::get() * 100),
-		])
-		.with_ctypes(vec![(attestation.ctype_hash, attester.clone())])
-		.with_delegation_hierarchies(vec![(
-			hierarchy_root_id,
-			hierarchy_details,
-			attester.clone(),
-			ACCOUNT_01,
-		)])
-		.with_delegations(vec![(delegation_id, delegation_node)])
-		.with_attestations(vec![(operation.claim_hash, attestation)])
-		.build()
-		.execute_with(|| {
-			assert_eq!(Balances::reserved_balance(ACCOUNT_00), <Test as Config>::Deposit::get());
-			assert!(
-				DelegatedAttestations::<Test>::get(delegation_id)
-					.unwrap_or_default()
-					.iter()
-					.any(|&ch| ch == operation.claim_hash),
-				"delegated attestation entry should be present before removal"
-			);
-
-			assert_ok!(Attestation::remove(
-				DoubleOrigin(ACCOUNT_00, attester.clone()).into(),
-				operation.claim_hash,
-				operation.max_parent_checks
-			));
-			assert!(Balances::reserved_balance(ACCOUNT_00).is_zero());
-			assert!(
-				!DelegatedAttestations::<Test>::get(delegation_id)
-					.unwrap_or_default()
-					.iter()
-					.any(|&ch| ch == operation.claim_hash),
-				"delegated attestation entry should be removed"
-			);
-		});
+fn test_reclaim_deposit_not_found() {
+	todo!()
 }

--- a/pallets/ctype/Cargo.toml
+++ b/pallets/ctype/Cargo.toml
@@ -13,7 +13,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-wasm-builder-runner = {version = "3.0.0"}
 
 [dev-dependencies]
-runtime-common = {default-features = false, path = "../../runtimes/common"}
 kilt-support = {features = ["mock"], path = "../../support"}
 pallet-balances = {branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate"}
 serde = {version = "1.0.124"}
@@ -27,7 +26,6 @@ scale-info = {version = "1.0", default-features = false, features = ["derive"]}
 serde = {optional = true, version = "1.0.124"}
 
 # Internal dependencies
-runtime-common = {default-features = false, optional = true, path = "../../runtimes/common"}
 kilt-support = {default-features = false, path = "../../support"}
 
 # Substrate dependencies
@@ -44,7 +42,6 @@ sp-std = {branch = "polkadot-v0.9.12", default-features = false, git = "https://
 [features]
 default = ["std"]
 mock = [
-  "runtime-common",
   "pallet-balances",
   "serde",
   "sp-core",
@@ -62,7 +59,6 @@ std = [
   "frame-benchmarking/std",
   "frame-support/std",
   "frame-system/std",
-  "runtime-common/std",
   "kilt-support/std",
   "log/std",
   "pallet-balances/std",

--- a/pallets/ctype/src/mock.rs
+++ b/pallets/ctype/src/mock.rs
@@ -36,21 +36,28 @@ where
 
 #[cfg(test)]
 pub mod runtime {
-	use frame_support::parameter_types;
+	use frame_support::{parameter_types, weights::constants::RocksDbWeight};
 	use kilt_support::mock::{mock_origin, SubjectId};
-	use runtime_common::{Balance, Header, RocksDbWeight};
 	use sp_runtime::{
+		testing::Header,
 		traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
-		AccountId32,
+		AccountId32, MultiSignature,
 	};
 
 	use crate::{BalanceOf, Ctypes};
 
 	use super::*;
 
-	pub type TestCtypeHash = runtime_common::Hash;
 	pub type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 	pub type Block = frame_system::mocking::MockBlock<Test>;
+	pub type Hash = sp_core::H256;
+	pub type Balance = u128;
+	pub type Signature = MultiSignature;
+	pub type AccountPublic = <Signature as Verify>::Signer;
+	pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+	pub const UNIT: Balance = 10u128.pow(15);
+	pub const MILLI_UNIT: Balance = 10u128.pow(12);
 
 	frame_support::construct_runtime!(
 		pub enum Test where
@@ -75,9 +82,9 @@ pub mod runtime {
 		type Call = Call;
 		type Index = u64;
 		type BlockNumber = u64;
-		type Hash = runtime_common::Hash;
+		type Hash = Hash;
 		type Hashing = BlakeTwo256;
-		type AccountId = <<runtime_common::Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+		type AccountId = AccountId;
 		type Lookup = IdentityLookup<Self::AccountId>;
 		type Header = Header;
 		type Event = ();
@@ -117,7 +124,7 @@ pub mod runtime {
 
 	impl mock_origin::Config for Test {
 		type Origin = Origin;
-		type AccountId = runtime_common::AccountId;
+		type AccountId = AccountId;
 		type SubjectId = SubjectId;
 	}
 
@@ -127,8 +134,8 @@ pub mod runtime {
 
 	impl Config for Test {
 		type CtypeCreatorId = SubjectId;
-		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<runtime_common::AccountId, SubjectId>;
-		type OriginSuccess = mock_origin::DoubleOrigin<runtime_common::AccountId, SubjectId>;
+		type EnsureOrigin = mock_origin::EnsureDoubleOrigin<AccountId, SubjectId>;
+		type OriginSuccess = mock_origin::DoubleOrigin<AccountId, SubjectId>;
 		type Event = ();
 		type WeightInfo = ();
 
@@ -138,21 +145,21 @@ pub mod runtime {
 	}
 
 	pub(crate) const DID_00: SubjectId = SubjectId(AccountId32::new([1u8; 32]));
-	pub(crate) const ACCOUNT_00: runtime_common::AccountId = runtime_common::AccountId::new([1u8; 32]);
+	pub(crate) const ACCOUNT_00: AccountId = AccountId::new([1u8; 32]);
 
 	#[derive(Clone, Default)]
 	pub(crate) struct ExtBuilder {
-		ctypes_stored: Vec<(TestCtypeHash, SubjectId)>,
-		balances: Vec<(runtime_common::AccountId, BalanceOf<Test>)>,
+		ctypes_stored: Vec<(CtypeHashOf<Test>, SubjectId)>,
+		balances: Vec<(AccountId, BalanceOf<Test>)>,
 	}
 
 	impl ExtBuilder {
-		pub(crate) fn with_ctypes(mut self, ctypes: Vec<(TestCtypeHash, SubjectId)>) -> Self {
+		pub(crate) fn with_ctypes(mut self, ctypes: Vec<(CtypeHashOf<Test>, SubjectId)>) -> Self {
 			self.ctypes_stored = ctypes;
 			self
 		}
 
-		pub(crate) fn with_balances(mut self, balances: Vec<(runtime_common::AccountId, BalanceOf<Test>)>) -> Self {
+		pub(crate) fn with_balances(mut self, balances: Vec<(AccountId, BalanceOf<Test>)>) -> Self {
 			self.balances = balances;
 			self
 		}

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -14,7 +14,6 @@ substrate-wasm-builder-runner = {version = "3.0.0"}
 
 [dev-dependencies]
 ctype = {features = ["mock"], path = "../ctype"}
-runtime-common = {default-features = false, path = "../../runtimes/common"}
 kilt-support = {features = ["mock"], path = "../../support"}
 
 # External dependencies
@@ -29,7 +28,6 @@ sp-keystore = {branch = "polkadot-v0.9.12", default-features = false, git = "htt
 [dependencies]
 # Internal dependencies
 ctype = {default-features = false, path = "../ctype"}
-runtime-common = {default-features = false, path = "../../runtimes/common"}
 kilt-support = {default-features = false, path = "../../support"}
 
 #External dependencies
@@ -73,7 +71,6 @@ std = [
   "ctype/std",
   "frame-support/std",
   "frame-system/std",
-  "runtime-common/std",
   "kilt-support/std",
   "log/std",
   "pallet-balances/std",

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -27,6 +27,7 @@ sp-keystore = {branch = "polkadot-v0.9.12", default-features = false, git = "htt
 
 [dependencies]
 # Internal dependencies
+attestation = {default-features = false, path = "../attestation"}
 ctype = {default-features = false, path = "../ctype"}
 kilt-support = {default-features = false, path = "../../support"}
 

--- a/pallets/delegation/src/default_weights.rs
+++ b/pallets/delegation/src/default_weights.rs
@@ -53,6 +53,7 @@ pub trait WeightInfo {
 	fn revoke_delegation_leaf(r: u32, c: u32, ) -> Weight;
 	fn remove_delegation(r: u32, ) -> Weight;
 	fn reclaim_deposit(r: u32, ) -> Weight;
+	fn is_delegating(r: u32, ) -> Weight;
 }
 
 /// Weights for delegation using the Substrate node and recommended hardware.
@@ -122,6 +123,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(r as Weight)))
 	}
+	// TODO: run benchmarks
+	fn is_delegating(r: u32, ) -> Weight {
+		(61_171_000_u64)
+			// Standard Error: 99_000
+			.saturating_add((37_949_000_u64).saturating_mul(r as Weight))
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(r as Weight)))
+	}
 }
 
 // For backwards compatibility and tests
@@ -174,4 +185,14 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(2_u64))
 			.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(r as Weight)))
 	}
+		// TODO: run benchmarks
+		fn is_delegating(r: u32, ) -> Weight {
+			(61_171_000_u64)
+				// Standard Error: 99_000
+				.saturating_add((37_949_000_u64).saturating_mul(r as Weight))
+				.saturating_add(RocksDbWeight::get().reads(2_u64))
+				.saturating_add(RocksDbWeight::get().reads((2_u64).saturating_mul(r as Weight)))
+				.saturating_add(RocksDbWeight::get().writes(2_u64))
+				.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(r as Weight)))
+		}
 }

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -13,6 +13,8 @@ scale-info = {version = "1.0", default-features = false, features = ["derive"]}
 serde = {version = "1.0.124", optional = true, features = ["derive"]}
 smallvec = "1.7.0"
 
+attestation = {default-features = false, path = "../../pallets/attestation"}
+
 frame-support = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12"}
 frame-system = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12"}
 pallet-authorship = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.12"}

--- a/runtimes/common/src/authorization.rs
+++ b/runtimes/common/src/authorization.rs
@@ -1,0 +1,57 @@
+use frame_support::dispatch::Weight;
+use sp_runtime::DispatchError;
+
+use attestation::AttestationAccessControl;
+
+pub enum AuthorizationId<DelegationId> {
+	Delegation(DelegationId),
+}
+
+pub enum PalletAuthorize<DelegationAc> {
+	Delegation(DelegationAc),
+}
+
+impl<T, DelegationAc, DelegationId> AttestationAccessControl<T::AttesterId, AuthorizationId<DelegationId>, T>
+	for PalletAuthorize<DelegationAc>
+where
+	T: attestation::Config<AuthorizationId = AuthorizationId<DelegationId>>,
+	DelegationAc: AttestationAccessControl<T::AttesterId, DelegationId, T>,
+{
+	fn can_attest(&self, who: &T::AttesterId) -> Result<frame_support::dispatch::Weight, DispatchError> {
+		match self {
+			PalletAuthorize::Delegation(ac) => ac.can_attest(who),
+		}
+	}
+
+	fn can_revoke(
+		&self,
+		who: &T::AttesterId,
+		attestation: &attestation::AttestationDetails<T>,
+	) -> Result<frame_support::dispatch::Weight, DispatchError> {
+		match self {
+			PalletAuthorize::Delegation(ac) => ac.can_revoke(who, attestation),
+		}
+	}
+
+	fn can_remove(
+		&self,
+		who: &T::AttesterId,
+		attestation: &attestation::AttestationDetails<T>,
+	) -> Result<frame_support::dispatch::Weight, DispatchError> {
+		match self {
+			PalletAuthorize::Delegation(ac) => ac.can_revoke(who, attestation),
+		}
+	}
+
+	fn authorization_id(&self) -> T::AuthorizationId {
+		match self {
+			PalletAuthorize::Delegation(ac) => AuthorizationId::Delegation(ac.authorization_id()),
+		}
+	}
+
+	fn weight(&self) -> Weight {
+		match self {
+			PalletAuthorize::Delegation(ac) => ac.weight(),
+		}
+	}
+}

--- a/runtimes/common/src/lib.rs
+++ b/runtimes/common/src/lib.rs
@@ -40,6 +40,7 @@ use sp_runtime::{
 pub mod constants;
 pub mod fees;
 pub mod pallet_id;
+pub mod authorization;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarks;

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -45,6 +45,7 @@ use sp_std::prelude::*;
 use sp_version::RuntimeVersion;
 
 use runtime_common::{
+	authorization::{AuthorizationId, PalletAuthorize},
 	constants::{self, KILT, MICRO_KILT, MILLI_KILT},
 	fees::{ToAuthor, WeightToFee},
 	pallet_id, AccountId, AuthorityId, Balance, BlockHashCount, BlockLength, BlockNumber, BlockWeights, DidIdentifier,
@@ -470,6 +471,10 @@ impl attestation::Config for Runtime {
 	type Currency = Balances;
 	type Deposit = AttestationDeposit;
 	type MaxDelegatedAttestations = MaxDelegatedAttestations;
+
+	type AttesterId = DidIdentifier;
+	type AuthorizationId = (); //AuthorizationId<DelegationAc>;
+	type AccessControl = (); //PalletAuthorize<Runtime, DelegationAc>;
 }
 
 parameter_types! {

--- a/runtimes/peregrine/src/weights/attestation.rs
+++ b/runtimes/peregrine/src/weights/attestation.rs
@@ -52,20 +52,16 @@ impl<T: frame_system::Config> attestation::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	fn revoke(d: u32, ) -> Weight {
+	fn revoke() -> Weight {
 		(37_043_000_u64)
 			// Standard Error: 45_000
-			.saturating_add((6_394_000_u64).saturating_mul(d as Weight))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	fn remove(d: u32, ) -> Weight {
+	fn remove() -> Weight {
 		(64_305_000_u64)
 			// Standard Error: 41_000
-			.saturating_add((6_297_000_u64).saturating_mul(d as Weight))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	fn reclaim_deposit() -> Weight {

--- a/runtimes/peregrine/src/weights/delegation.rs
+++ b/runtimes/peregrine/src/weights/delegation.rs
@@ -112,4 +112,15 @@ impl<T: frame_system::Config> delegation::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
 	}
+
+	// TODO: run benchmarks
+	fn is_delegating(r: u32, ) -> Weight {
+		(53_098_000 as Weight)
+			// Standard Error: 75_000
+			.saturating_add((39_041_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
+	}
 }

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -476,6 +476,9 @@ impl attestation::Config for Runtime {
 	type Currency = Balances;
 	type Deposit = AttestationDeposit;
 	type MaxDelegatedAttestations = MaxDelegatedAttestations;
+	type AttesterId = DidIdentifier;
+	type AuthorizationId = ();
+	type AccessControl = ();
 }
 
 parameter_types! {

--- a/runtimes/spiritnet/src/weights/attestation.rs
+++ b/runtimes/spiritnet/src/weights/attestation.rs
@@ -52,20 +52,16 @@ impl<T: frame_system::Config> attestation::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
-	fn revoke(d: u32, ) -> Weight {
+	fn revoke() -> Weight {
 		(37_282_000_u64)
 			// Standard Error: 42_000
-			.saturating_add((6_344_000_u64).saturating_mul(d as Weight))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
-	fn remove(d: u32, ) -> Weight {
+	fn remove() -> Weight {
 		(64_367_000_u64)
 			// Standard Error: 58_000
-			.saturating_add((6_230_000_u64).saturating_mul(d as Weight))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
-			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(d as Weight)))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	fn reclaim_deposit() -> Weight {

--- a/runtimes/spiritnet/src/weights/delegation.rs
+++ b/runtimes/spiritnet/src/weights/delegation.rs
@@ -112,4 +112,15 @@ impl<T: frame_system::Config> delegation::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
 	}
+
+	// TODO: run benchmarks
+	fn is_delegating(r: u32) -> Weight {
+		(53_370_000 as Weight)
+			// Standard Error: 126_000
+			.saturating_add((39_346_000 as Weight).saturating_mul(r as Weight))
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().reads((2 as Weight).saturating_mul(r as Weight)))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+			.saturating_add(T::DbWeight::get().writes((2 as Weight).saturating_mul(r as Weight)))
+	}
 }

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -314,6 +314,9 @@ impl attestation::Config for Runtime {
 	type Currency = Balances;
 	type Deposit = AttestationDeposit;
 	type MaxDelegatedAttestations = MaxDelegatedAttestations;
+	type AttesterId = DidIdentifier;
+	type AuthorizationId = ();
+	type AccessControl = ();
 }
 
 parameter_types! {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1697

* Use generic `AuthorizationId` in attestation
* add AuthorizationId enum to runtime-common
  * each method has it's own variant
  * first and only variant is the delegation pallet
* add AccessControl trait

## How to test:


## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
