### PR TITLE
feat: bound pallets in runtime storage size

### DIFF
--- a/pallets/attestation/src/attestations.rs
+++ b/pallets/attestation/src/attestations.rs
@@ -27,7 +27,7 @@ use crate::{AccountIdOf, AttesterOf, BalanceOf, Config};
 /// An on-chain attestation written by an attester.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-#[codec(mel_bound(CtypeHashOf<T>: MaxEncodedLen, AttesterOf<T>: MaxEncodedLen, DelegationNodeIdOf<T>: MaxEncodedLen))]
+#[codec(mel_bound())]
 pub struct AttestationDetails<T: Config> {
 	/// The hash of the CType used for this attestation.
 	pub ctype_hash: CtypeHashOf<T>,

--- a/pallets/attestation/src/attestations.rs
+++ b/pallets/attestation/src/attestations.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use ctype::CtypeHashOf;
 use delegation::DelegationNodeIdOf;
 use kilt_support::deposit::Deposit;
@@ -25,8 +25,10 @@ use scale_info::TypeInfo;
 use crate::{AccountIdOf, AttesterOf, BalanceOf, Config};
 
 /// An on-chain attestation written by an attester.
-#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
+// TODO: Check whether we should provide input
+#[codec(mel_bound())]
 pub struct AttestationDetails<T: Config> {
 	/// The hash of the CType used for this attestation.
 	pub ctype_hash: CtypeHashOf<T>,
@@ -41,3 +43,4 @@ pub struct AttestationDetails<T: Config> {
 	/// storage.
 	pub deposit: Deposit<AccountIdOf<T>, BalanceOf<T>>,
 }
+

--- a/pallets/attestation/src/attestations.rs
+++ b/pallets/attestation/src/attestations.rs
@@ -27,8 +27,7 @@ use crate::{AccountIdOf, AttesterOf, BalanceOf, Config};
 /// An on-chain attestation written by an attester.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-// TODO: Check whether we should provide input
-#[codec(mel_bound())]
+#[codec(mel_bound(CtypeHashOf<T>: MaxEncodedLen, AttesterOf<T>: MaxEncodedLen, DelegationNodeIdOf<T>: MaxEncodedLen))]
 pub struct AttestationDetails<T: Config> {
 	/// The hash of the CType used for this attestation.
 	pub ctype_hash: CtypeHashOf<T>,
@@ -43,4 +42,3 @@ pub struct AttestationDetails<T: Config> {
 	/// storage.
 	pub deposit: Deposit<AccountIdOf<T>, BalanceOf<T>>,
 }
-

--- a/pallets/attestation/src/lib.rs
+++ b/pallets/attestation/src/lib.rs
@@ -141,7 +141,6 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]

--- a/pallets/ctype/src/lib.rs
+++ b/pallets/ctype/src/lib.rs
@@ -96,7 +96,7 @@ pub mod pallet {
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
 		type Currency: Currency<AccountIdOf<Self>>;
 		type WeightInfo: WeightInfo;
-		type CtypeCreatorId: Parameter;
+		type CtypeCreatorId: Parameter + MaxEncodedLen;
 		type Fee: Get<BalanceOf<Self>>;
 		type FeeCollector: OnUnbalanced<NegativeImbalanceOf<Self>>;
 	}
@@ -104,7 +104,6 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::hooks]

--- a/pallets/delegation/src/delegation_hierarchy.rs
+++ b/pallets/delegation/src/delegation_hierarchy.rs
@@ -166,8 +166,7 @@ impl<T: Config> DelegationDetails<T> {
 /// The details associated with a delegation hierarchy.
 #[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-// TODO: Check whether we should provide input
-#[codec(mel_bound())]
+#[codec(mel_bound(CtypeHashOf<T>: MaxEncodedLen))]
 
 pub struct DelegationHierarchyDetails<T: Config> {
 	/// The authorised CTYPE hash that attesters can attest using this

--- a/pallets/delegation/src/delegation_hierarchy.rs
+++ b/pallets/delegation/src/delegation_hierarchy.rs
@@ -18,7 +18,7 @@
 
 use crate::{AccountIdOf, BalanceOf, Config, DelegationNodeIdOf, DelegatorIdOf, Error};
 use bitflags::bitflags;
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use ctype::CtypeHashOf;
 use frame_support::{dispatch::DispatchResult, storage::bounded_btree_set::BoundedBTreeSet};
 use kilt_support::deposit::Deposit;
@@ -28,7 +28,7 @@ bitflags! {
 	/// Bitflags for permissions.
 	///
 	/// Permission bits can be combined to express multiple permissions.
-	#[derive(Encode, Decode, TypeInfo)]
+	#[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
 	pub struct Permissions: u32 {
 		/// Permission to write attestations on chain.
 		const ATTEST = 0b0000_0001;
@@ -75,6 +75,13 @@ pub struct DelegationNode<T: Config> {
 	/// The deposit that was taken to incentivise fair use of the on chain
 	/// storage.
 	pub deposit: Deposit<AccountIdOf<T>, BalanceOf<T>>,
+}
+
+impl<T: Config> MaxEncodedLen for DelegationNode<T> {
+	fn max_encoded_len() -> usize {
+		// BoundedBTreeSet::<DelegationNodeIdOf<T>, T::MaxChildren>::max_encoded_len()
+		1usize
+	}
 }
 
 impl<T: Config> DelegationNode<T> {
@@ -129,7 +136,7 @@ impl<T: Config> DelegationNode<T> {
 }
 
 /// Delegation information attached to delegation nodes.
-#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 
 pub struct DelegationDetails<T: Config> {
@@ -157,8 +164,10 @@ impl<T: Config> DelegationDetails<T> {
 }
 
 /// The details associated with a delegation hierarchy.
-#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, TypeInfo)]
+#[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
+// TODO: Check whether we should provide input
+#[codec(mel_bound())]
 
 pub struct DelegationHierarchyDetails<T: Config> {
 	/// The authorised CTYPE hash that attesters can attest using this

--- a/pallets/delegation/src/delegation_hierarchy.rs
+++ b/pallets/delegation/src/delegation_hierarchy.rs
@@ -60,9 +60,9 @@ impl Default for Permissions {
 /// For quicker lookups of the hierarchy details, all nodes maintain a direct
 /// link to the hierarchy root node. Furthermore, all nodes have a parent except
 /// the root nodes, which point to themselves for the hierarchy root node link.
-#[derive(Clone, Encode, Decode, PartialEq, TypeInfo)]
+#[derive(Clone, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-
+#[codec(mel_bound())]
 pub struct DelegationNode<T: Config> {
 	/// The ID of the delegation hierarchy the node is part of.
 	pub hierarchy_root_id: DelegationNodeIdOf<T>,
@@ -75,13 +75,6 @@ pub struct DelegationNode<T: Config> {
 	/// The deposit that was taken to incentivise fair use of the on chain
 	/// storage.
 	pub deposit: Deposit<AccountIdOf<T>, BalanceOf<T>>,
-}
-
-impl<T: Config> MaxEncodedLen for DelegationNode<T> {
-	fn max_encoded_len() -> usize {
-		// BoundedBTreeSet::<DelegationNodeIdOf<T>, T::MaxChildren>::max_encoded_len()
-		1usize
-	}
 }
 
 impl<T: Config> DelegationNode<T> {
@@ -138,7 +131,7 @@ impl<T: Config> DelegationNode<T> {
 /// Delegation information attached to delegation nodes.
 #[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-
+#[codec(mel_bound())]
 pub struct DelegationDetails<T: Config> {
 	/// The owner of the delegation (and its node).
 	pub owner: DelegatorIdOf<T>,
@@ -166,7 +159,7 @@ impl<T: Config> DelegationDetails<T> {
 /// The details associated with a delegation hierarchy.
 #[derive(Clone, Debug, Encode, Decode, Eq, PartialEq, Ord, PartialOrd, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-#[codec(mel_bound(CtypeHashOf<T>: MaxEncodedLen))]
+#[codec(mel_bound())]
 
 pub struct DelegationHierarchyDetails<T: Config> {
 	/// The authorised CTYPE hash that attesters can attest using this

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -94,7 +94,6 @@ use frame_support::{
 	pallet_prelude::Weight,
 	traits::{Get, ReservableCurrency},
 };
-use migrations::DelegationStorageVersion;
 use sp_runtime::{traits::Hash, DispatchError};
 use sp_std::vec::Vec;
 
@@ -102,7 +101,10 @@ use sp_std::vec::Vec;
 pub mod pallet {
 
 	use super::*;
-	use frame_support::{pallet_prelude::*, traits::Currency};
+	use frame_support::{
+		pallet_prelude::*,
+		traits::{Currency, StorageVersion},
+	};
 	use frame_system::pallet_prelude::*;
 	use kilt_support::{
 		signature::{SignatureVerificationError, VerifySignature},
@@ -187,11 +189,6 @@ pub mod pallet {
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
-
-	/// Contains the latest storage version deployed.
-	#[pallet::storage]
-	#[pallet::getter(fn last_version_migration_used)]
-	pub(crate) type StorageVersion<T> = StorageValue<_, DelegationStorageVersion, ValueQuery>;
 
 	/// Delegation nodes stored on chain.
 	///

--- a/pallets/delegation/src/lib.rs
+++ b/pallets/delegation/src/lib.rs
@@ -110,6 +110,9 @@ pub mod pallet {
 	};
 	use scale_info::TypeInfo;
 
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
+
 	/// Type of a delegation node identifier.
 	pub type DelegationNodeIdOf<T> = <T as Config>::DelegationNodeId;
 
@@ -182,6 +185,7 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
+	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 
 	/// Contains the latest storage version deployed.

--- a/pallets/delegation/src/migrations.rs
+++ b/pallets/delegation/src/migrations.rs
@@ -16,13 +16,13 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 // FIXME: Remove when migrating to v8
 // #[deprecated(note = "use the pallet's `current_storage_version()` instead")]
 /// Storage version of the delegation pallet.
-#[derive(Copy, Clone, Encode, Eq, Decode, Ord, PartialEq, PartialOrd, TypeInfo)]
+#[derive(Copy, Clone, Encode, Eq, Decode, Ord, PartialEq, PartialOrd, TypeInfo, MaxEncodedLen)]
 pub enum DelegationStorageVersion {
 	V1,
 	V2,

--- a/pallets/did/src/did_details.rs
+++ b/pallets/did/src/did_details.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use codec::{Decode, Encode, WrapperTypeEncode};
+use codec::{Decode, Encode, MaxEncodedLen, WrapperTypeEncode};
 use frame_support::{
 	ensure,
 	storage::{bounded_btree_map::BoundedBTreeMap, bounded_btree_set::BoundedBTreeSet},
@@ -35,7 +35,7 @@ use crate::{
 };
 
 /// Types of verification keys a DID can control.
-#[derive(Clone, Decode, Debug, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo)]
+#[derive(Clone, Decode, Debug, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo, MaxEncodedLen)]
 pub enum DidVerificationKey {
 	/// An Ed25519 public key.
 	Ed25519(ed25519::Public),
@@ -86,14 +86,14 @@ impl From<ecdsa::Public> for DidVerificationKey {
 }
 
 /// Types of encryption keys a DID can control.
-#[derive(Clone, Copy, Decode, Debug, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo)]
+#[derive(Clone, Copy, Decode, Debug, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo, MaxEncodedLen)]
 pub enum DidEncryptionKey {
 	/// An X25519 public key.
 	X25519([u8; 32]),
 }
 
 /// A general public key under the control of the DID.
-#[derive(Clone, Decode, Debug, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo)]
+#[derive(Clone, Decode, Debug, Encode, Eq, Ord, PartialEq, PartialOrd, TypeInfo, MaxEncodedLen)]
 pub enum DidPublicKey {
 	/// A verification key, used to generate and verify signatures.
 	PublicVerificationKey(DidVerificationKey),
@@ -115,7 +115,7 @@ impl From<DidEncryptionKey> for DidPublicKey {
 
 /// Verification methods a verification key can
 /// fulfil, according to the [DID specification](https://w3c.github.io/did-spec-registries/#verification-relationships).
-#[derive(Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, TypeInfo)]
+#[derive(Clone, Copy, Debug, Decode, Encode, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub enum DidVerificationKeyRelationship {
 	/// Key used to authenticate all the DID operations.
 	Authentication,
@@ -229,9 +229,9 @@ impl DidVerifiableIdentifier for runtime_common::DidIdentifier {
 ///
 /// It is currently used to keep track of all the past and current
 /// attestation keys a DID might control.
-#[derive(Clone, Debug, Decode, Encode, PartialEq, Ord, PartialOrd, Eq, TypeInfo)]
+#[derive(Clone, Debug, Decode, Encode, PartialEq, Ord, PartialOrd, Eq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-
+#[codec(mel_bound(DidPublicKey: MaxEncodedLen))]
 pub struct DidPublicKeyDetails<T: Config> {
 	/// A public key the DID controls.
 	pub key: DidPublicKey,
@@ -240,8 +240,9 @@ pub struct DidPublicKeyDetails<T: Config> {
 }
 
 /// The details associated to a DID identity.
-#[derive(Clone, Decode, Encode, PartialEq, TypeInfo)]
+#[derive(Clone, Decode, Encode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
+#[codec(mel_bound(DidKeyAgreementKeySet<T>: MaxEncodedLen, DidPublicKeyMap<T>: MaxEncodedLen))]
 
 pub struct DidDetails<T: Config> {
 	/// The ID of the authentication key, used to authenticate DID-related

--- a/pallets/did/src/did_details.rs
+++ b/pallets/did/src/did_details.rs
@@ -231,7 +231,7 @@ impl DidVerifiableIdentifier for runtime_common::DidIdentifier {
 /// attestation keys a DID might control.
 #[derive(Clone, Debug, Decode, Encode, PartialEq, Ord, PartialOrd, Eq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-#[codec(mel_bound(DidPublicKey: MaxEncodedLen))]
+#[codec(mel_bound())]
 pub struct DidPublicKeyDetails<T: Config> {
 	/// A public key the DID controls.
 	pub key: DidPublicKey,
@@ -242,7 +242,7 @@ pub struct DidPublicKeyDetails<T: Config> {
 /// The details associated to a DID identity.
 #[derive(Clone, Decode, Encode, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-#[codec(mel_bound(DidKeyAgreementKeySet<T>: MaxEncodedLen, DidPublicKeyMap<T>: MaxEncodedLen))]
+#[codec(mel_bound())]
 
 pub struct DidDetails<T: Config> {
 	/// The ID of the authentication key, used to authenticate DID-related

--- a/pallets/did/src/lib.rs
+++ b/pallets/did/src/lib.rs
@@ -192,7 +192,7 @@ pub mod pallet {
 			+ DeriveDidCallAuthorizationVerificationKeyRelationship;
 
 		/// Type for a DID subject identifier.
-		type DidIdentifier: Parameter + Default + DidVerifiableIdentifier;
+		type DidIdentifier: Parameter + Default + DidVerifiableIdentifier + MaxEncodedLen;
 
 		/// Origin type expected by the proxied dispatchable calls.
 		#[cfg(not(feature = "runtime-benchmarks"))]
@@ -284,7 +284,6 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	/// DIDs stored on chain.

--- a/pallets/did/src/origin.rs
+++ b/pallets/did/src/origin.rs
@@ -16,6 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
+use codec::MaxEncodedLen;
 use frame_support::{
 	codec::{Decode, Encode},
 	traits::EnsureOrigin,
@@ -26,7 +27,7 @@ use sp_runtime::RuntimeDebug;
 use sp_std::marker::PhantomData;
 
 /// Origin for modules that support DID-based authorization.
-#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo)]
+#[derive(Clone, Decode, Encode, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct DidRawOrigin<DidIdentifier, AccountId> {
 	pub id: DidIdentifier,
 	pub submitter: AccountId,

--- a/pallets/did/src/service_endpoints.rs
+++ b/pallets/did/src/service_endpoints.rs
@@ -17,7 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use crate::{errors::InputError, Config};
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use frame_support::{ensure, traits::Get, BoundedVec};
 use scale_info::TypeInfo;
 use sp_runtime::traits::SaturatedConversion;
@@ -43,8 +43,9 @@ pub(crate) type ServiceEndpointUrlEntries<T> =
 	BoundedVec<ServiceEndpointUrl<T>, <T as Config>::MaxNumberOfUrlsPerService>;
 
 /// A single service endpoint description.
-#[derive(Clone, Decode, Encode, PartialEq, Eq, TypeInfo)]
+#[derive(Clone, Decode, Encode, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
+#[codec(mel_bound(ServiceEndpointId<T>: MaxEncodedLen, ServiceEndpointTypeEntries<T>: MaxEncodedLen, ServiceEndpointUrlEntries<T>: MaxEncodedLen))]
 pub struct DidEndpoint<T: Config> {
 	/// The ID of the service endpoint. Allows the endpoint to be queried and
 	/// resolved directly.

--- a/pallets/did/src/service_endpoints.rs
+++ b/pallets/did/src/service_endpoints.rs
@@ -45,7 +45,7 @@ pub(crate) type ServiceEndpointUrlEntries<T> =
 /// A single service endpoint description.
 #[derive(Clone, Decode, Encode, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
-#[codec(mel_bound(ServiceEndpointId<T>: MaxEncodedLen, ServiceEndpointTypeEntries<T>: MaxEncodedLen, ServiceEndpointUrlEntries<T>: MaxEncodedLen))]
+#[codec(mel_bound())]
 pub struct DidEndpoint<T: Config> {
 	/// The ID of the service endpoint. Allows the endpoint to be queried and
 	/// resolved directly.

--- a/pallets/kilt-launch/src/lib.rs
+++ b/pallets/kilt-launch/src/lib.rs
@@ -151,7 +151,7 @@ pub mod pallet {
 
 	#[derive(Debug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(T))]
-	#[codec(mel_bound(<T as frame_system::Config>::BlockNumber: MaxEncodedLen))]
+	#[codec(mel_bound())]
 	pub struct LockedBalance<T: Config> {
 		pub block: <T as frame_system::Config>::BlockNumber,
 		pub amount: <T as pallet_balances::Config>::Balance,

--- a/pallets/kilt-launch/src/lib.rs
+++ b/pallets/kilt-launch/src/lib.rs
@@ -149,10 +149,11 @@ pub mod pallet {
 	pub const KILT_LAUNCH_ID: LockIdentifier = *b"kiltlnch";
 	pub const VESTING_ID: LockIdentifier = *b"vesting ";
 
-	#[derive(Debug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo)]
+	#[derive(Debug, Encode, Decode, PartialEq, Eq, Clone, TypeInfo, MaxEncodedLen)]
 	#[scale_info(skip_type_params(T))]
+	#[codec(mel_bound(<T as frame_system::Config>::BlockNumber: MaxEncodedLen))]
 	pub struct LockedBalance<T: Config> {
-		pub block: T::BlockNumber,
+		pub block: <T as frame_system::Config>::BlockNumber,
 		pub amount: <T as pallet_balances::Config>::Balance,
 	}
 
@@ -192,7 +193,6 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	#[pallet::genesis_config]

--- a/pallets/pallet-did-lookup/src/connection_record.rs
+++ b/pallets/pallet-did-lookup/src/connection_record.rs
@@ -16,12 +16,12 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use kilt_support::deposit::Deposit;
 use scale_info::TypeInfo;
 
 /// A record in the ConnectedDid map.
-#[derive(Clone, Decode, Debug, Encode, TypeInfo, PartialEq)]
+#[derive(Clone, Decode, Debug, Encode, TypeInfo, PartialEq, MaxEncodedLen)]
 pub struct ConnectionRecord<DidIdentifier, Account, Balance> {
 	/// The did that is connected to the key under which the record was stored.
 	pub did: DidIdentifier,

--- a/pallets/pallet-did-lookup/src/lib.rs
+++ b/pallets/pallet-did-lookup/src/lib.rs
@@ -85,7 +85,7 @@ pub mod pallet {
 		type OriginSuccess: CallSources<AccountIdOf<Self>, DidIdentifierOf<Self>>;
 
 		/// The identifier to which accounts can get associated.
-		type DidIdentifier: Parameter + Default;
+		type DidIdentifier: Parameter + Default + MaxEncodedLen;
 
 		/// The currency that is used to reserve funds for each did.
 		type Currency: ReservableCurrency<AccountIdOf<Self>>;
@@ -102,7 +102,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 

--- a/pallets/pallet-inflation/src/lib.rs
+++ b/pallets/pallet-inflation/src/lib.rs
@@ -82,7 +82,6 @@ pub mod pallet {
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
-	#[pallet::without_storage_info]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
 

--- a/pallets/pallet-web3-names/src/lib.rs
+++ b/pallets/pallet-web3-names/src/lib.rs
@@ -69,7 +69,6 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(_);
 
 	/// Map of name -> ownership details.
@@ -111,9 +110,15 @@ pub mod pallet {
 		#[pallet::constant]
 		type MaxNameLength: Get<u32>;
 		/// The type of a name.
-		type Web3Name: FullCodec + Debug + PartialEq + Clone + TypeInfo + TryFrom<Vec<u8>, Error = Error<Self>>;
+		type Web3Name: FullCodec
+			+ Debug
+			+ PartialEq
+			+ Clone
+			+ TypeInfo
+			+ TryFrom<Vec<u8>, Error = Error<Self>>
+			+ MaxEncodedLen;
 		/// The type of a name owner.
-		type Web3NameOwner: Parameter + Default;
+		type Web3NameOwner: Parameter + Default + MaxEncodedLen;
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
 	}

--- a/pallets/pallet-web3-names/src/web3_name.rs
+++ b/pallets/pallet-web3-names/src/web3_name.rs
@@ -30,8 +30,9 @@ use crate::{Config, Error};
 ///
 /// It is bounded in size (inclusive range [MinLength, MaxLength]) and can only
 /// contain a subset of ASCII characters.
-#[derive(Encode, Decode, TypeInfo)]
+#[derive(Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T, MinLength, MaxLength))]
+#[codec(mel_bound())]
 pub struct AsciiWeb3Name<T: Config, MinLength: Get<u32>, MaxLength: Get<u32>>(
 	pub(crate) BoundedVec<u8, MaxLength>,
 	PhantomData<(T, MinLength)>,
@@ -52,14 +53,6 @@ impl<T: Config> TryFrom<Vec<u8>> for AsciiWeb3Name<T, T::MinNameLength, T::MaxNa
 			BoundedVec::try_from(value).map_err(|_| Self::Error::Web3NameTooLong)?;
 		ensure!(is_valid_web3_name(&bounded_vec), Self::Error::InvalidWeb3NameCharacter);
 		Ok(Self(bounded_vec, PhantomData))
-	}
-}
-
-// required because else T would have to impl MaxEncodedLen, e.g. TestMock and
-// Runtime
-impl<T: Config> MaxEncodedLen for AsciiWeb3Name<T, T::MinNameLength, T::MaxNameLength> {
-	fn max_encoded_len() -> usize {
-		frame_support::BoundedVec::<u8, T::MaxNameLength>::max_encoded_len()
 	}
 }
 

--- a/pallets/parachain-staking/src/inflation.rs
+++ b/pallets/parachain-staking/src/inflation.rs
@@ -18,7 +18,7 @@
 
 //! Helper methods for computing issuance based on inflation
 use crate::{pallet::Config, types::BalanceOf};
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use runtime_common::constants::BLOCKS_PER_YEAR;
 use scale_info::TypeInfo;
 use sp_runtime::{traits::Saturating, Perquintill, RuntimeDebug};
@@ -31,6 +31,13 @@ use serde::{Deserialize, Serialize};
 pub struct RewardRate {
 	pub annual: Perquintill,
 	pub per_block: Perquintill,
+}
+
+impl MaxEncodedLen for RewardRate {
+	fn max_encoded_len() -> usize {
+		// Perquintill is at most u128
+		u128::max_encoded_len().saturating_add(u128::max_encoded_len())
+	}
 }
 
 /// Convert annual reward rate to per_block.
@@ -55,6 +62,13 @@ pub struct StakingInfo {
 	pub max_rate: Perquintill,
 	/// Reward rate annually and per_block.
 	pub reward_rate: RewardRate,
+}
+
+impl MaxEncodedLen for StakingInfo {
+	fn max_encoded_len() -> usize {
+		// Perquintill is at most u128
+		RewardRate::max_encoded_len().saturating_add(u128::max_encoded_len())
+	}
 }
 
 impl StakingInfo {
@@ -86,7 +100,7 @@ impl StakingInfo {
 }
 
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Eq, PartialEq, Clone, Encode, Decode, Default, RuntimeDebug, TypeInfo)]
+#[derive(Eq, PartialEq, Clone, Encode, Decode, Default, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct InflationInfo {
 	pub collator: StakingInfo,
 	pub delegator: StakingInfo,

--- a/pallets/parachain-staking/src/lib.rs
+++ b/pallets/parachain-staking/src/lib.rs
@@ -220,7 +220,6 @@ pub mod pallet {
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
 	#[pallet::storage_version(STORAGE_VERSION)]
-	#[pallet::without_storage_info]
 	pub struct Pallet<T>(PhantomData<T>);
 
 	/// Configuration trait of this pallet.
@@ -251,7 +250,8 @@ pub mod pallet {
 			+ From<u128>
 			+ Into<<Self as pallet_balances::Config>::Balance>
 			+ From<<Self as pallet_balances::Config>::Balance>
-			+ TypeInfo;
+			+ TypeInfo
+			+ MaxEncodedLen;
 
 		/// Minimum number of blocks validation rounds can last.
 		#[pallet::constant]

--- a/pallets/parachain-staking/src/set.rs
+++ b/pallets/parachain-staking/src/set.rs
@@ -17,7 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use frame_support::{traits::Get, BoundedVec, DefaultNoBound};
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{traits::Zero, SaturatedConversion};
 use sp_std::{
@@ -30,8 +30,9 @@ use sp_std::{
 use sp_std::{fmt, prelude::*};
 
 /// An ordered set backed by `BoundedVec`.
-#[derive(PartialEq, Eq, Encode, Decode, DefaultNoBound, Clone, TypeInfo)]
+#[derive(PartialEq, Eq, Encode, Decode, DefaultNoBound, Clone, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(S))]
+#[codec(mel_bound(T: MaxEncodedLen))]
 pub struct OrderedSet<T, S: Get<u32>>(BoundedVec<T, S>);
 
 impl<T: Ord + Clone, S: Get<u32>> OrderedSet<T, S> {

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -105,7 +105,7 @@ impl Default for CandidateStatus {
 
 #[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxDelegatorsPerCandidate))]
-#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen, MaxDelegatorsPerCandidate: Get<u32>))]
+#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen))]
 /// Global collator state with commission fee, staked funds, and delegations
 pub struct Candidate<AccountId, Balance, MaxDelegatorsPerCandidate>
 where
@@ -213,7 +213,7 @@ where
 
 #[derive(Encode, Decode, RuntimeDebug, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxCollatorsPerDelegator))]
-#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen, MaxCollatorsPerDelegator: Get<u32>))]
+#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen))]
 pub struct Delegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
 	pub delegations: OrderedSet<Stake<AccountId, Balance>, MaxCollatorsPerDelegator>,
 	pub total: Balance,

--- a/pallets/parachain-staking/src/types.rs
+++ b/pallets/parachain-staking/src/types.rs
@@ -17,7 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 use frame_support::traits::{Currency, Get};
-use parity_scale_codec::{Decode, Encode};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
 	traits::{AtLeast32BitUnsigned, Saturating, Zero},
@@ -38,7 +38,8 @@ use crate::{set::OrderedSet, Config};
 ///
 /// The stake has a destination account (to which the stake is directed) and an
 /// amount of funds staked.
-#[derive(Default, Clone, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo)]
+#[derive(Default, Clone, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen))]
 pub struct Stake<AccountId, Balance>
 where
 	AccountId: Eq + Ord,
@@ -88,7 +89,7 @@ impl<AccountId: Ord, Balance: PartialEq + Ord> Ord for Stake<AccountId, Balance>
 }
 
 /// The activity status of the collator.
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum CandidateStatus {
 	/// Committed to be online and producing valid blocks (not equivocating)
 	Active,
@@ -102,8 +103,9 @@ impl Default for CandidateStatus {
 	}
 }
 
-#[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo)]
+#[derive(Encode, Decode, Clone, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxDelegatorsPerCandidate))]
+#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen, MaxDelegatorsPerCandidate: Get<u32>))]
 /// Global collator state with commission fee, staked funds, and delegations
 pub struct Candidate<AccountId, Balance, MaxDelegatorsPerCandidate>
 where
@@ -209,8 +211,9 @@ where
 	}
 }
 
-#[derive(Encode, Decode, RuntimeDebug, PartialEq, TypeInfo)]
+#[derive(Encode, Decode, RuntimeDebug, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(MaxCollatorsPerDelegator))]
+#[codec(mel_bound(AccountId: MaxEncodedLen, Balance: MaxEncodedLen, MaxCollatorsPerDelegator: Get<u32>))]
 pub struct Delegator<AccountId: Eq + Ord, Balance: Eq + Ord, MaxCollatorsPerDelegator: Get<u32>> {
 	pub delegations: OrderedSet<Stake<AccountId, Balance>, MaxCollatorsPerDelegator>,
 	pub total: Balance,
@@ -306,7 +309,7 @@ where
 }
 
 /// The current round index and transition information.
-#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo)]
+#[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub struct RoundInfo<BlockNumber> {
 	/// Current round index.
 	pub current: SessionIndex,
@@ -352,7 +355,7 @@ where
 /// The total stake of the pallet.
 ///
 /// The stake includes both collators' and delegators' staked funds.
-#[derive(Default, Clone, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo)]
+#[derive(Default, Clone, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub struct TotalStake<Balance: Default> {
 	pub collators: Balance,
 	pub delegators: Balance,
@@ -360,7 +363,7 @@ pub struct TotalStake<Balance: Default> {
 
 /// The number of delegations a delegator has done within the last session in
 /// which they delegated.
-#[derive(Default, Clone, Encode, Decode, RuntimeDebug, PartialEq, TypeInfo)]
+#[derive(Default, Clone, Encode, Decode, RuntimeDebug, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct DelegationCounter {
 	/// The index of the last delegation.
 	pub round: SessionIndex,

--- a/support/src/deposit.rs
+++ b/support/src/deposit.rs
@@ -15,11 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 
 /// An amount of balance reserved by the specified address.
-#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo)]
+#[derive(Clone, Debug, Encode, Decode, PartialEq, TypeInfo, MaxEncodedLen)]
 pub struct Deposit<Account, Balance> {
 	pub owner: Account,
 	pub amount: Balance,

--- a/support/src/mock.rs
+++ b/support/src/mock.rs
@@ -17,7 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
 ///! This module contains utilities for testing.
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::sr25519;
 use sp_runtime::AccountId32;
@@ -112,7 +112,7 @@ pub mod mock_origin {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Default, MaxEncodedLen)]
 pub struct SubjectId(pub AccountId32);
 
 impl From<AccountId32> for SubjectId {


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1777
* Implements/derives `MaxEncodedLen` for all required pallets' structs such that each pallet's storage size is bound
* Removes `#[pallet::without_storage_info]` from all pallets 

The usage of the `#[codec(mel_bound(Generic: TraitBound))]` feature is often required because the compiler is not smart enough to derive `MaxEncodedLen`
* `mel_bound()` means no bound is added at all. We can use this if encapsulated associated types are already bound by the `MaxEncodedLen` trait
* If we provide attributes, we tell the macro which trait bounds to add. This was only required in the staking pallet where we used unbound generics for the AccountId and balance. In 8a5d744a54343062f1d74d778e43a4c7410a7e3f you can see how many bounds could be removed eventually. Shawn did it similarly in [this Substrate PR](https://github.com/paritytech/substrate/commit/54dc43478f9f4f252fe692bffb83f867c29638cb#diff-2d9d52e6c7d98cac411c9f83d851a0ee4cfaad74140ac2d0a2a07007db1a1f3eL342)

## Checklist:

- [x] I have verified that the code works
  - [x] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [x] I have verified that the code is easy to understand
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [x] I have documented the changes (where applicable)
