### PR TITLE
fix: Adds two more bootnodes for peregrine relaychain

### DIFF
--- a/.maintain/reset-spec/peregrine_relay.py
+++ b/.maintain/reset-spec/peregrine_relay.py
@@ -13,6 +13,8 @@ def update_spec(input: typing.Dict, base_chain="westend"):
             "/dns4/eyrie-2.kilt.io/tcp/30361/p2p/12D3KooWHq5j9tLdZEu4tnr6ii2k33zp5DCoKREQ6KzuabC9Gihu",
             "/dns4/eyrie-2.kilt.io/tcp/30362/p2p/12D3KooWQ8iTGLH98zLz9BZmq5FXDmR1NytDsJ2VToXvcjvHV16a",
             "/dns4/eyrie-1.kilt.io/tcp/30363/p2p/12D3KooWNWNptEoH443LVUgwC5kd7DBVoNYwQtJh6dp4TQxUsAST",
+            "/dns4/eyrie-3.kilt.io/tcp/30365/p2p/12D3KooWCYnLwW3eEWiWqBNraUDjp8qVg2uwyJxh9fKAs32PMutR",
+            "/dns4/eyrie-3.kilt.io/tcp/30366/p2p/12D3KooWCED7zzribj75pE98739qp8QNDDfXFmL2w6JMLwBWFLxL",
         ],
         "chainType": "Live",
         "name": "Peregrine Relay",

--- a/dev-specs/kilt-parachain/peregrine-relay.json
+++ b/dev-specs/kilt-parachain/peregrine-relay.json
@@ -6,7 +6,9 @@
     "/dns4/eyrie-1.kilt.io/tcp/30360/p2p/12D3KooWEeezCpJauUmWw3zfgEtYzhZTc5LgukQYtGTMaZfzgVfE",
     "/dns4/eyrie-2.kilt.io/tcp/30361/p2p/12D3KooWHq5j9tLdZEu4tnr6ii2k33zp5DCoKREQ6KzuabC9Gihu",
     "/dns4/eyrie-2.kilt.io/tcp/30362/p2p/12D3KooWQ8iTGLH98zLz9BZmq5FXDmR1NytDsJ2VToXvcjvHV16a",
-    "/dns4/eyrie-1.kilt.io/tcp/30363/p2p/12D3KooWNWNptEoH443LVUgwC5kd7DBVoNYwQtJh6dp4TQxUsAST"
+    "/dns4/eyrie-1.kilt.io/tcp/30363/p2p/12D3KooWNWNptEoH443LVUgwC5kd7DBVoNYwQtJh6dp4TQxUsAST",
+    "/dns4/eyrie-3.kilt.io/tcp/30365/p2p/12D3KooWCYnLwW3eEWiWqBNraUDjp8qVg2uwyJxh9fKAs32PMutR",
+    "/dns4/eyrie-3.kilt.io/tcp/30366/p2p/12D3KooWCED7zzribj75pE98739qp8QNDDfXFmL2w6JMLwBWFLxL"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1822
Adds two more peregrine relaychain bootnodes

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
