### PR TITLE
ci: use custom ci image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ test-features:
 
 build:
   image:
-    name: amazon/aws-cli:2.2.38
+    name: kiltprotocol/kilt-ci
     entrypoint: [""]
   stage: build
   only:
@@ -46,7 +46,6 @@ build:
     DOCKER_HUB_PARACHAIN: "kiltprotocol/kilt-node"
     DOCKER_HUB_STANDALONE: "kiltprotocol/mashnet-node"
   before_script:
-    - amazon-linux-extras install docker
     - aws --version
     - docker --version
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ test-features:
 
 build:
   image:
-    name: kiltprotocol/kilt-ci
+    name: kiltprotocol/kilt-ci:2.2.38
     entrypoint: [""]
   stage: build
   only:

--- a/.maintain/ci.Dockerfile
+++ b/.maintain/ci.Dockerfile
@@ -1,0 +1,3 @@
+FROM amazon/aws-cli:2.2.38
+
+RUN amazon-linux-extras install docker


### PR DESCRIPTION
skipping one step should speed up the build

[The Dockerfile can be found in our deployment repository](https://github.com/KILTprotocol/kubernetes/blob/master/container/ci.Dockerfile)