### PR TITLE
chore: v1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "attestation"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "ctype",
  "delegation",
@@ -1367,7 +1367,7 @@ dependencies = [
 
 [[package]]
 name = "ctype"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "delegation"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "bitflags",
  "ctype",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "did"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "ctype",
  "env_logger 0.8.4",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-launch"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-parachain"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "clap",
  "cumulus-client-cli",
@@ -3600,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "kilt-support"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4470,7 +4470,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "clap",
  "frame-benchmarking",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "mashnet-node-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "attestation",
  "bitflags",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-did-lookup"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5784,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-inflation"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6315,7 +6315,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-web3-names"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6381,7 +6381,7 @@ dependencies = [
 
 [[package]]
 name = "parachain-staking"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6653,7 +6653,7 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "peregrine-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "attestation",
  "ctype",
@@ -8567,7 +8567,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-common"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10827,7 +10827,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spiritnet-runtime"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "attestation",
  "ctype",

--- a/nodes/parachain/Cargo.toml
+++ b/nodes/parachain/Cargo.toml
@@ -4,7 +4,7 @@ build = "build.rs"
 description = "KILT parachain"
 edition = "2021"
 name = "kilt-parachain"
-version = "1.6.0"
+version = "1.6.1"
 
 [[bin]]
 name = "kilt-parachain"

--- a/nodes/standalone/Cargo.toml
+++ b/nodes/standalone/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["KILT <info@kilt.io>"]
 build = "build.rs"
 edition = "2021"
 name = "mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [[bin]]
 name = "mashnet-node"

--- a/pallets/attestation/Cargo.toml
+++ b/pallets/attestation/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding and revoking attestations."
 edition = "2021"
 name = "attestation"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/ctype/Cargo.toml
+++ b/pallets/ctype/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding CTypes."
 edition = "2021"
 name = "ctype"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/delegation/Cargo.toml
+++ b/pallets/delegation/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables creating and revoking root nodes of delegation hierarchie
 edition = "2021"
 name = "delegation"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/did/Cargo.toml
+++ b/pallets/did/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables adding and removing decentralized identifiers (DIDs)."
 edition = "2021"
 name = "did"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/kilt-launch/Cargo.toml
+++ b/pallets/kilt-launch/Cargo.toml
@@ -4,7 +4,7 @@ description = "Enables automatic unlocking of balance from genesis block"
 edition = "2021"
 name = "kilt-launch"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/pallet-did-lookup/Cargo.toml
+++ b/pallets/pallet-did-lookup/Cargo.toml
@@ -4,7 +4,7 @@ description = "Lookup the DID for a blockchain account."
 edition = "2021"
 name = "pallet-did-lookup"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/pallet-inflation/Cargo.toml
+++ b/pallets/pallet-inflation/Cargo.toml
@@ -4,7 +4,7 @@ description = "Substrate pallet issueing a pre-configured amount of tokens to th
 edition = "2021"
 name = "pallet-inflation"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/pallet-web3-names/Cargo.toml
+++ b/pallets/pallet-web3-names/Cargo.toml
@@ -4,7 +4,7 @@ description = "Unique Web3 nicknames for KILT DIDs."
 edition = "2021"
 name = "pallet-web3-names"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/pallets/parachain-staking/Cargo.toml
+++ b/pallets/parachain-staking/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["KILT <info@kilt.io>"]
 description = "Parachain parachain-staking pallet for collator delegation and selection as well as reward distribution"
 edition = "2021"
 name = "parachain-staking"
-version = "1.6.0"
+version = "1.6.1"
 
 [dev-dependencies]
 pallet-aura = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false}

--- a/runtimes/common/Cargo.toml
+++ b/runtimes/common/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "runtime-common"
-version = "1.6.0"
+version = "1.6.1"
 
 [dev-dependencies]
 sp-io = {git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.17"}

--- a/runtimes/peregrine/Cargo.toml
+++ b/runtimes/peregrine/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "peregrine-runtime"
-version = "1.6.0"
+version = "1.6.1"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17"}

--- a/runtimes/peregrine/src/lib.rs
+++ b/runtimes/peregrine/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 10600,
+	spec_version: 10610,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/runtimes/spiritnet/Cargo.toml
+++ b/runtimes/spiritnet/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "spiritnet-runtime"
-version = "1.6.0"
+version = "1.6.1"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17"}

--- a/runtimes/spiritnet/src/lib.rs
+++ b/runtimes/spiritnet/src/lib.rs
@@ -79,7 +79,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("kilt-spiritnet"),
 	impl_name: create_runtime_str!("kilt-spiritnet"),
 	authoring_version: 1,
-	spec_version: 10600,
+	spec_version: 10610,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/standalone/Cargo.toml
+++ b/runtimes/standalone/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["KILT <info@kilt.io>"]
 edition = "2021"
 name = "mashnet-node-runtime"
-version = "1.6.0"
+version = "1.6.1"
 
 [build-dependencies]
 substrate-wasm-builder = {git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17"}

--- a/runtimes/standalone/src/lib.rs
+++ b/runtimes/standalone/src/lib.rs
@@ -114,7 +114,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("mashnet-node"),
 	impl_name: create_runtime_str!("mashnet-node"),
 	authoring_version: 4,
-	spec_version: 10600,
+	spec_version: 10610,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/support/Cargo.toml
+++ b/support/Cargo.toml
@@ -4,7 +4,7 @@ description = "Shared traits and structs used across the KILT pallets"
 edition = "2021"
 name = "kilt-support"
 repository = "https://github.com/KILTprotocol/mashnet-node"
-version = "1.6.0"
+version = "1.6.1"
 
 [dependencies]
 codec = {default-features = false, features = ["derive"], package = "parity-scale-codec", version = "2.3.1"}


### PR DESCRIPTION
Supersedes https://github.com/KILTprotocol/mashnet-node/pull/346 (branch renaming).