### PR TITLE
feat: reset team on refund

### DIFF
--- a/crates/kilt-dip-primitives/src/merkle_proofs/v0/provider_state/tests.rs
+++ b/crates/kilt-dip-primitives/src/merkle_proofs/v0/provider_state/tests.rs
@@ -251,7 +251,7 @@ mod dip_did_proof_with_verified_relay_state_root {
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 		type Nonce = u64;
 		type OnKilledAccount = ();
 		type OnNewAccount = ();

--- a/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
+++ b/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
@@ -71,7 +71,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -261,7 +261,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/ctype/src/mock.rs
+++ b/pallets/ctype/src/mock.rs
@@ -100,7 +100,7 @@ pub mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/delegation/src/mock.rs
+++ b/pallets/delegation/src/mock.rs
@@ -247,7 +247,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -105,7 +105,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-asset-switch/src/mock.rs
+++ b/pallets/pallet-asset-switch/src/mock.rs
@@ -66,7 +66,7 @@ impl frame_system::Config for MockRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -315,6 +315,8 @@ pub mod pallet {
 		Slippage,
 		/// The calculated collateral is zero.
 		ZeroCollateral,
+		/// A pool has to contain at least one bonded currency.
+		ZeroBondedCurrency,
 	}
 
 	#[pallet::call]
@@ -372,6 +374,7 @@ pub mod pallet {
 			let checked_curve = curve.try_into().map_err(|_| Error::<T>::InvalidInput)?;
 
 			let currency_length = currencies.len();
+			ensure!(!currency_length.is_zero(), Error::<T>::ZeroBondedCurrency);
 
 			let currency_ids = T::NextAssetIds::try_get(currency_length.saturated_into())
 				.map_err(|e| e.into())

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -64,7 +64,7 @@ pub mod pallet {
 				Create as CreateFungibles, Destroy as DestroyFungibles, Inspect as InspectFungibles,
 				Mutate as MutateFungibles,
 			},
-			tokens::{Fortitude, Precision as WithdrawalPrecision, Preservation, Provenance},
+			tokens::{DepositConsequence, Fortitude, Precision as WithdrawalPrecision, Preservation, Provenance},
 			AccountTouch,
 		},
 		Hashable, Parameter,
@@ -1119,8 +1119,7 @@ pub mod pallet {
 
 			if amount.is_zero()
 				|| T::Collaterals::can_deposit(pool_details.collateral.clone(), &who, amount, Provenance::Extant)
-					.into_result()
-					.is_err()
+					== DepositConsequence::BelowMinimum
 			{
 				// Funds are burnt but the collateral received is not sufficient to be deposited
 				// to the account. This is tolerated as otherwise we could have edge cases where

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -449,18 +449,17 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Changes the managing team of a bonded currency which is issued by
-		/// this pool. The new team will be set to the provided team. The
-		/// currency index is used to select the currency that the team will
-		/// manage. The origin account must be a manager of the pool.
+		/// Changes the managing team of all bonded currencies issued by this
+		/// pool, setting it to the provided `team`. The origin account must be
+		/// a manager of the pool.
 		///
 		/// # Parameters
 		/// - `origin`: The origin of the call, requiring the caller to be a
 		///   manager of the pool.
 		/// - `pool_id`: The identifier of the pool.
 		/// - `team`: The new managing team.
-		/// - `currency_idx`: The index of the currency in the bonded currencies
-		///   vector.
+		/// - `currency_count`: The number of bonded currencies vector linked to
+		///   the pool. Required for weight estimations.
 		///
 		/// # Returns
 		/// - `DispatchResult`: The result of the dispatch.
@@ -469,8 +468,8 @@ pub mod pallet {
 		/// - `Error::<T>::PoolUnknown`: If the pool does not exist.
 		/// - `Error::<T>::NoPermission`: If the caller is not a manager of the
 		///   pool.
-		/// - `Error::<T>::IndexOutOfBounds`: If the currency index is out of
-		///   bounds.
+		/// - `Error::<T>::CurrencyCount`: If the actual number of currencies in
+		///   the pool is larger than `currency_count`.
 		/// - Other errors depending on the types in the config.
 		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::reset_team())]
@@ -478,31 +477,31 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			pool_id: T::PoolId,
 			team: PoolManagingTeam<AccountIdOf<T>>,
-			currency_idx: u32,
+			currency_count: u32,
 		) -> DispatchResult {
 			let who = T::DefaultOrigin::ensure_origin(origin)?;
 
 			let pool_details = Pools::<T>::get(&pool_id).ok_or(Error::<T>::PoolUnknown)?;
 
+			let number_of_currencies = Self::get_currencies_number(&pool_details);
+			ensure!(number_of_currencies <= currency_count, Error::<T>::CurrencyCount);
+
 			ensure!(pool_details.is_manager(&who), Error::<T>::NoPermission);
 			ensure!(pool_details.state.is_live(), Error::<T>::PoolNotLive);
-
-			let asset_id = pool_details
-				.bonded_currencies
-				.get(currency_idx.saturated_into::<usize>())
-				.ok_or(Error::<T>::IndexOutOfBounds)?;
 
 			let pool_id_account = pool_id.into();
 
 			let PoolManagingTeam { freezer, admin } = team;
 
-			T::Fungibles::reset_team(
-				asset_id.to_owned(),
-				pool_id_account.clone(),
-				admin,
-				pool_id_account,
-				freezer,
-			)
+			pool_details.bonded_currencies.into_iter().try_for_each(|asset_id| {
+				T::Fungibles::reset_team(
+					asset_id,
+					pool_id_account.clone(),
+					admin.clone(),
+					pool_id_account.clone(),
+					freezer.clone(),
+				)
+			})
 		}
 
 		/// Resets the manager of a pool. The new manager will be set to the

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -249,7 +249,7 @@ pub mod runtime {
 		type Hash = Hash;
 		type Hashing = BlakeTwo256;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 		type Nonce = u64;
 		type OnKilledAccount = ();
 		type OnNewAccount = ();

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -58,6 +58,7 @@ pub mod runtime {
 		weights::constants::RocksDbWeight,
 	};
 	use frame_system::{EnsureRoot, EnsureSigned};
+	use pallet_assets::FrozenBalance;
 	use sp_core::U256;
 	use sp_runtime::{
 		traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
@@ -69,7 +70,7 @@ pub mod runtime {
 		self as pallet_bonded_coins,
 		traits::NextAssetIds,
 		types::{Locks, PoolStatus},
-		Config, DepositBalanceOf, FungiblesAssetIdOf, PoolDetailsOf,
+		AccountIdOf, Config, DepositBalanceOf, FungiblesAssetIdOf, FungiblesBalanceOf, PoolDetailsOf,
 	};
 
 	pub type Hash = sp_core::H256;
@@ -190,6 +191,28 @@ pub mod runtime {
 		}
 	}
 
+	/// Store freezes for the assets pallet.
+	#[storage_alias]
+	pub type Freezes<Assets: PalletInfoAccess> = StorageDoubleMap<
+		Assets,
+		Blake2_128Concat,
+		FungiblesAssetIdOf<Test>,
+		Blake2_128Concat,
+		AccountIdOf<Test>,
+		FungiblesBalanceOf<Test>,
+		OptionQuery,
+	>;
+
+	pub struct FreezesHook;
+
+	impl FrozenBalance<AssetId, AccountId, Balance> for FreezesHook {
+		fn died(_asset: AssetId, _who: &AccountId) {}
+
+		fn frozen_balance(asset: AssetId, who: &AccountId) -> Option<Balance> {
+			Freezes::<Assets>::get(asset, who)
+		}
+	}
+
 	frame_support::construct_runtime!(
 		pub enum Test
 		{
@@ -279,7 +302,7 @@ pub mod runtime {
 		type Currency = Balances;
 		type Extra = ();
 		type ForceOrigin = EnsureRoot<AccountId>;
-		type Freezer = ();
+		type Freezer = FreezesHook;
 		type MetadataDepositBase = ConstU128<0>;
 		type MetadataDepositPerByte = ConstU128<0>;
 		type RemoveItemsLimit = ConstU32<5>;
@@ -355,6 +378,7 @@ pub mod runtime {
 		//  pool_id, PoolDetails
 		pools: Vec<(AccountId, PoolDetailsOf<Test>)>,
 		collaterals: Vec<AssetId>,
+		freezes: Vec<(AssetId, AccountId, Balance)>,
 	}
 
 	impl ExtBuilder {
@@ -375,6 +399,11 @@ pub mod runtime {
 
 		pub(crate) fn with_bonded_balance(mut self, bonded_balance: Vec<(AssetId, AccountId, Balance)>) -> Self {
 			self.bonded_balance = bonded_balance;
+			self
+		}
+
+		pub(crate) fn with_freezes(mut self, freezes: Vec<(AssetId, AccountId, Balance)>) -> Self {
+			self.freezes = freezes;
 			self
 		}
 
@@ -448,6 +477,10 @@ pub mod runtime {
 				});
 
 				NextAssetId::<BondingPallet>::set(next_asset_id);
+
+				self.freezes.iter().for_each(|(asset_id, account, amount)| {
+					Freezes::<Assets>::set(asset_id, account, Some(*amount));
+				});
 			});
 
 			ext

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -51,13 +51,57 @@ fn resets_team() {
 					admin: ACCOUNT_00,
 					freezer: ACCOUNT_01,
 				},
-				0
+				1
 			));
 
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_01));
 			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::issuer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id));
+		})
+}
+
+#[test]
+fn resets_team_for_all() {
+	let currencies = vec![DEFAULT_BONDED_CURRENCY_ID, DEFAULT_BONDED_CURRENCY_ID + 1];
+
+	let pool_details = generate_pool_details(
+		currencies.clone(),
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+		None,
+	);
+	let pool_id: AccountIdOf<Test> = calculate_pool_id(&currencies);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::reset_team(
+				manager_origin,
+				pool_id.clone(),
+				PoolManagingTeam {
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				},
+				2
+			));
+
+			assert_eq!(Assets::admin(currencies[0]), Some(ACCOUNT_00));
+			assert_eq!(Assets::freezer(currencies[0]), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(currencies[0]), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(currencies[0]), Some(pool_id.clone()));
+
+			assert_eq!(Assets::admin(currencies[1]), Some(ACCOUNT_00));
+			assert_eq!(Assets::freezer(currencies[1]), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(currencies[1]), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(currencies[1]), Some(pool_id));
 		})
 }
 
@@ -89,7 +133,7 @@ fn does_not_change_team_when_not_live() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::PoolNotLive
 			);
@@ -130,7 +174,7 @@ fn only_manager_can_change_team() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::NoPermission
 			);
@@ -143,7 +187,7 @@ fn only_manager_can_change_team() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::NoPermission
 			);
@@ -153,7 +197,7 @@ fn only_manager_can_change_team() {
 }
 
 #[test]
-fn handles_currency_idx_out_of_bounds() {
+fn handles_currency_number_incorrect() {
 	let pool_details = generate_pool_details(
 		vec![DEFAULT_BONDED_CURRENCY_ID],
 		get_linear_bonding_curve(),
@@ -180,9 +224,9 @@ fn handles_currency_idx_out_of_bounds() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					2
+					0
 				),
-				BondingPalletErrors::<Test>::IndexOutOfBounds
+				BondingPalletErrors::<Test>::CurrencyCount
 			);
 		})
 }

--- a/pallets/pallet-configuration/src/mock.rs
+++ b/pallets/pallet-configuration/src/mock.rs
@@ -79,7 +79,7 @@ pub mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/pallet-deposit-storage/src/deposit/mock.rs
+++ b/pallets/pallet-deposit-storage/src/deposit/mock.rs
@@ -73,7 +73,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
@@ -75,7 +75,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-deposit-storage/src/mock.rs
+++ b/pallets/pallet-deposit-storage/src/mock.rs
@@ -60,7 +60,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -80,7 +80,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-dip-consumer/src/mock.rs
+++ b/pallets/pallet-dip-consumer/src/mock.rs
@@ -54,7 +54,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-dip-provider/src/mock.rs
+++ b/pallets/pallet-dip-provider/src/mock.rs
@@ -54,7 +54,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-inflation/src/mock.rs
+++ b/pallets/pallet-inflation/src/mock.rs
@@ -82,7 +82,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-migration/src/mock.rs
+++ b/pallets/pallet-migration/src/mock.rs
@@ -114,7 +114,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-relay-store/src/mock.rs
+++ b/pallets/pallet-relay-store/src/mock.rs
@@ -53,7 +53,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-web3-names/src/mock.rs
+++ b/pallets/pallet-web3-names/src/mock.rs
@@ -114,7 +114,7 @@ pub(crate) mod runtime {
 		type SystemWeightInfo = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 		type RuntimeTask = RuntimeTask;
 	}
 

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -92,7 +92,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 1;

--- a/pallets/public-credentials/src/mock.rs
+++ b/pallets/public-credentials/src/mock.rs
@@ -302,7 +302,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = ConstU16<38>;
 		type OnSetCode = ();
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 	}
 
 	impl pallet_balances::Config for Test {

--- a/runtimes/common/src/dip/deposit/mock.rs
+++ b/runtimes/common/src/dip/deposit/mock.rs
@@ -52,7 +52,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = Hash;
 	type Hashing = Hasher;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = Nonce;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/runtimes/common/src/dip/mock.rs
+++ b/runtimes/common/src/dip/mock.rs
@@ -74,7 +74,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = Hash;
 	type Hashing = Hasher;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = Nonce;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/runtimes/common/src/fees.rs
+++ b/runtimes/common/src/fees.rs
@@ -219,7 +219,7 @@ mod tests {
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	impl pallet_balances::Config for Test {

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -198,7 +198,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	/// The set code logic, just the default since we're not a parachain.
 	type OnSetCode = ();
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 }
 
 /// Maximum number of nominators per validator.

--- a/runtimes/peregrine/src/system/mod.rs
+++ b/runtimes/peregrine/src/system/mod.rs
@@ -93,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<SS_58_PREFIX>;
 	/// The set code logic
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/runtimes/spiritnet/src/system/mod.rs
+++ b/runtimes/spiritnet/src/system/mod.rs
@@ -93,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<SS_58_PREFIX>;
 	/// The set code logic
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
Suggested change to avoid unexpected changes to currencies and issuances while refunding. This resets all asset teams to the pool account when calling `start_refund`.

This is waiting for a runtime implementation of our new pallet so that we can see the impact on the transaction weight that this has.

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
