### PR TITLE
fix: audit issue 1

### DIFF
--- a/crates/kilt-dip-primitives/src/merkle_proofs/v0/provider_state/tests.rs
+++ b/crates/kilt-dip-primitives/src/merkle_proofs/v0/provider_state/tests.rs
@@ -251,7 +251,7 @@ mod dip_did_proof_with_verified_relay_state_root {
 		type Hash = H256;
 		type Hashing = BlakeTwo256;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 		type Nonce = u64;
 		type OnKilledAccount = ();
 		type OnNewAccount = ();

--- a/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
+++ b/crates/kilt-dip-primitives/src/verifier/parachain/v0/mock.rs
@@ -71,7 +71,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/attestation/src/mock.rs
+++ b/pallets/attestation/src/mock.rs
@@ -261,7 +261,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/ctype/src/mock.rs
+++ b/pallets/ctype/src/mock.rs
@@ -100,7 +100,7 @@ pub mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/delegation/src/mock.rs
+++ b/pallets/delegation/src/mock.rs
@@ -247,7 +247,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/did/src/mock.rs
+++ b/pallets/did/src/mock.rs
@@ -105,7 +105,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-asset-switch/src/mock.rs
+++ b/pallets/pallet-asset-switch/src/mock.rs
@@ -66,7 +66,7 @@ impl frame_system::Config for MockRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -28,6 +28,7 @@ use substrate_fixed::traits::{Fixed, FixedSigned, FixedUnsigned, ToFixed};
 use crate::{
 	curves::{
 		lmsr::{LMSRParameters, LMSRParametersInput},
+		polynomial::PolynomialParameters,
 		square_root::{SquareRootParameters, SquareRootParametersInput},
 		Curve, CurveInput,
 	},
@@ -62,6 +63,13 @@ where
 	}
 
 	fn set_native_balance(_account: &<T>::AccountId, _amount: u128) {}
+}
+
+fn get_2nd_order_polynomial_curve<Float: FixedSigned>() -> Curve<Float> {
+	let m = Float::from_num(0.01);
+	let n = Float::from_num(2);
+	let o = Float::from_num(3);
+	Curve::Polynomial(PolynomialParameters { m, n, o })
 }
 
 fn get_square_root_curve<Float: FixedSigned>() -> Curve<Float> {
@@ -314,7 +322,7 @@ mod benchmarks {
 			Curve::SquareRoot(_) => {
 				assert_eq!(id, expected_pool_id);
 			}
-			_ => panic!("pool.curve is not a Polynomial function"),
+			_ => panic!("pool.curve is not a SquareRoot function"),
 		}
 	}
 
@@ -351,7 +359,7 @@ mod benchmarks {
 			Curve::Lmsr(_) => {
 				assert_eq!(id, expected_pool_id);
 			}
-			_ => panic!("pool.curve is not a Polynomial function"),
+			_ => panic!("pool.curve is not a LSMR curve!"),
 		}
 	}
 
@@ -485,7 +493,7 @@ mod benchmarks {
 		make_free_for_deposit::<T>(&account_origin);
 		set_collateral_balance::<T>(collateral_id.clone(), &account_origin, 10000u128);
 
-		let curve = get_linear_bonding_curve::<CurveParameterTypeOf<T>>();
+		let curve = get_2nd_order_polynomial_curve::<CurveParameterTypeOf<T>>();
 		let bonded_currencies = create_bonded_currencies_in_range::<T>(c, false);
 
 		let pool_id = create_pool::<T>(curve, bonded_currencies.clone(), None, None, Some(0));
@@ -615,7 +623,7 @@ mod benchmarks {
 		let start_balance = 100u128;
 		set_fungible_balance::<T>(target_asset_id.clone(), &account_origin, start_balance);
 
-		let curve = get_linear_bonding_curve::<CurveParameterTypeOf<T>>();
+		let curve = get_2nd_order_polynomial_curve::<CurveParameterTypeOf<T>>();
 
 		let pool_id = create_pool::<T>(curve, bonded_currencies, None, None, Some(0));
 		let pool_account = pool_id.clone().into();

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -236,6 +236,7 @@ mod benchmarks {
 				transferable: true,
 				allow_reset_team: true,
 				min_operation_balance: 1u128.saturated_into(),
+				max_supply: u128::MAX.saturated_into(),
 			},
 			deposit: Pallet::<T>::calculate_pool_deposit(bonded_coin_ids.len()),
 		};
@@ -280,7 +281,8 @@ mod benchmarks {
 				denomination: 10,
 				allow_reset_team: true,
 				transferable: true,
-				min_operation_balance: 1,
+				min_operation_balance: 1u128.saturated_into(),
+				max_supply: 10_000u128.saturated_into(),
 			},
 		);
 
@@ -321,7 +323,8 @@ mod benchmarks {
 				denomination: 10,
 				allow_reset_team: true,
 				transferable: true,
-				min_operation_balance: 1,
+				min_operation_balance: 1u128.saturated_into(),
+				max_supply: 10_000u128.saturated_into(),
 			},
 		);
 
@@ -361,7 +364,8 @@ mod benchmarks {
 				denomination: 10,
 				allow_reset_team: true,
 				transferable: true,
-				min_operation_balance: 1,
+				min_operation_balance: 1u128.saturated_into(),
+				max_supply: 10_000u128.saturated_into(),
 			},
 		);
 

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -17,6 +17,7 @@
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 use frame_benchmarking::v2::*;
 use frame_support::traits::fungibles::roles::Inspect as InspectRoles;
+use scale_info::prelude::format;
 use sp_core::U256;
 use sp_std::{
 	ops::{AddAssign, BitOrAssign, ShlAssign},
@@ -233,11 +234,11 @@ mod benchmarks {
 
 	fn generate_token_metadata<T: Config>(c: u32) -> BoundedVec<TokenMetaOf<T>, T::MaxCurrenciesPerPool> {
 		let mut token_meta = Vec::new();
-		for _ in 1..=c {
+		for i in 1..=c {
 			token_meta.push(TokenMetaOf::<T> {
 				min_balance: 1u128.saturated_into(),
-				name: BoundedVec::try_from(b"BTC".to_vec()).expect("Failed to create BoundedVec"),
-				symbol: BoundedVec::try_from(b"BTC".to_vec()).expect("Failed to create BoundedVec"),
+				name: BoundedVec::try_from(format!("Coin_{}", &i).into_bytes()).expect("Failed to create BoundedVec"),
+				symbol: BoundedVec::try_from(format!("BTC_{}", &i).into_bytes()).expect("Failed to create BoundedVec"),
 			})
 		}
 		BoundedVec::try_from(token_meta).expect("creating bounded Vec should not fail")

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -32,6 +32,7 @@ use crate::{
 		square_root::{SquareRootParameters, SquareRootParametersInput},
 		Curve, CurveInput,
 	},
+	types::BondedCurrenciesSettings,
 	Call, CollateralAssetIdOf, CollateralBalanceOf, Config, CurveParameterTypeOf, FungiblesAssetIdOf,
 	FungiblesBalanceOf, Pallet,
 };
@@ -229,10 +230,13 @@ mod benchmarks {
 			owner,
 			state,
 			collateral,
-			denomination,
 			bonded_currencies: BoundedVec::truncate_from(bonded_coin_ids.clone()),
-			transferable: true,
-			min_operation_balance: 1u128.saturated_into(),
+			currencies_settings: BondedCurrenciesSettings {
+				denomination,
+				transferable: true,
+				allow_reset_team: true,
+				min_operation_balance: 1u128.saturated_into(),
+			},
 			deposit: Pallet::<T>::calculate_pool_deposit(bonded_coin_ids.len()),
 		};
 		Pools::<T>::insert(&pool_id, pool_details);
@@ -272,9 +276,12 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			10,
-			true,
-			1,
+			BondedCurrenciesSettings {
+				denomination: 10,
+				allow_reset_team: true,
+				transferable: true,
+				min_operation_balance: 1,
+			},
 		);
 
 		// Verify
@@ -310,9 +317,12 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			10,
-			true,
-			1,
+			BondedCurrenciesSettings {
+				denomination: 10,
+				allow_reset_team: true,
+				transferable: true,
+				min_operation_balance: 1,
+			},
 		);
 
 		// Verify
@@ -347,9 +357,12 @@ mod benchmarks {
 			curve,
 			collateral_id,
 			currencies,
-			10,
-			true,
-			1,
+			BondedCurrenciesSettings {
+				denomination: 10,
+				allow_reset_team: true,
+				transferable: true,
+				min_operation_balance: 1,
+			},
 		);
 
 		// Verify

--- a/pallets/pallet-bonded-coins/src/benchmarking.rs
+++ b/pallets/pallet-bonded-coins/src/benchmarking.rs
@@ -369,6 +369,10 @@ mod benchmarks {
 		let curve = get_linear_bonding_curve::<CurveParameterTypeOf<T>>();
 		let pool_id = create_pool::<T>(curve, bonded_currencies.clone(), Some(account_origin), None, None);
 
+		// Although these would rarely happen in practice, for benchmarking we assume
+		// the worst case where the owner must be changed as well
+		assert!(T::Fungibles::owner(bonded_currencies[0].clone()) != Some(pool_id.clone().into()));
+
 		let admin: AccountIdOf<T> = account("admin", 0, 0);
 		let freezer: AccountIdOf<T> = account("freezer", 0, 0);
 		let fungibles_team = PoolManagingTeam {
@@ -376,14 +380,23 @@ mod benchmarks {
 			freezer: freezer.clone(),
 		};
 
+		let pool_id_for_call = pool_id.clone();
+
 		let max_currencies = T::MaxCurrenciesPerPool::get();
 		#[extrinsic_call]
-		_(origin as T::RuntimeOrigin, pool_id, fungibles_team, max_currencies);
+		_(
+			origin as T::RuntimeOrigin,
+			pool_id_for_call,
+			fungibles_team,
+			max_currencies,
+		);
 
 		// Verify
 		bonded_currencies.iter().for_each(|asset_id| {
 			assert_eq!(T::Fungibles::admin(asset_id.clone()), Some(admin.clone()));
 			assert_eq!(T::Fungibles::freezer(asset_id.clone()), Some(freezer.clone()));
+			assert_eq!(T::Fungibles::owner(asset_id.clone()), Some(pool_id.clone().into()));
+			assert_eq!(T::Fungibles::issuer(asset_id.clone()), Some(pool_id.clone().into()));
 		});
 	}
 

--- a/pallets/pallet-bonded-coins/src/curves/mod.rs
+++ b/pallets/pallet-bonded-coins/src/curves/mod.rs
@@ -166,7 +166,7 @@ pub fn balance_to_fixed<Balance, FixedType: Fixed>(
 	round_kind: Round,
 ) -> Result<FixedType, ArithmeticError>
 where
-	FixedType::Bits: TryFrom<U256>, // TODO: make large integer type configurable in runtime
+	FixedType::Bits: TryFrom<U256>,
 	Balance: TryInto<U256>,
 {
 	let decimals = U256::from(10u8)

--- a/pallets/pallet-bonded-coins/src/curves/polynomial.rs
+++ b/pallets/pallet-bonded-coins/src/curves/polynomial.rs
@@ -34,13 +34,19 @@
 /// ### Antiderivative
 /// The indefinite integral of the cost function is:
 /// ```text
-/// C(s) = (m / 3) * s^3 + (n / 2) * s^2 + o * s
+/// C(s) = (m / 3) * s^3 + (n / 2) * s^2 + o * s = M * s^3 + N * s^2 + O * s
 /// ```
 /// Where:
 /// - `m` is the coefficient for the quadratic term,
 /// - `n` is the coefficient for the linear term,
-/// - `o` is the constant term.
+/// - `o` is the constant term,
+/// - `M` is the coefficient of the first (cubic) term in the antiderivative,
+/// - `N` is the coefficient of the second (quadratic) term in the
+///   antiderivative,
+/// - `O=o` is the coefficient of the third (linear) term in the antiderivative.
 ///
+/// Coefficients of the antiderivative `N`, `M` & `O` are used to parametrize
+/// functions in this module.
 ///
 /// `C(s)` represents the accumulated cost of purchasing or selling assets up to
 /// the current supply `s`. The integral between two supply points, `s*`
@@ -81,9 +87,11 @@ use crate::PassiveSupply;
 ///
 /// For a polynomial cost function `c(s) = 3 * s^2 + 2 * s + 2`
 ///
-/// which is resulting into the antiderivative
-/// `C(s) = (3 / 3) * s^3 + (2 / 2) * s^2 + 2 * s`
-/// the input parameters would be:
+/// which results in the antiderivative
+/// `C(s) = (3 / 3) * s^3 + (2 / 2) * s^2 + 2 * s = 1 * s^3 + 1 * s^2 + 2 * s`
+///
+/// the input parameters `M`, `N` & `O` (coefficients of the antiderivative)
+/// would be:
 /// ```rust, ignore
 /// PolynomialParametersInput {
 ///    m: 1,

--- a/pallets/pallet-bonded-coins/src/curves/polynomial.rs
+++ b/pallets/pallet-bonded-coins/src/curves/polynomial.rs
@@ -152,27 +152,33 @@ where
 			.checked_add(accumulated_passive_issuance)
 			.ok_or(ArithmeticError::Overflow)?;
 
-		// Calculate high - low
-		let delta_x = high.checked_sub(low).ok_or(ArithmeticError::Underflow)?;
-
-		let high_low_mul = high.checked_mul(low).ok_or(ArithmeticError::Overflow)?;
-		let high_square = square(high)?;
-		let low_square = square(low)?;
-
-		// Factorized cubic term:  (high^2 + high * low + low^2)
-		let cubic_term = high_square
-			.checked_add(high_low_mul)
-			.ok_or(ArithmeticError::Overflow)?
-			.checked_add(low_square)
-			.ok_or(ArithmeticError::Overflow)?;
-
 		// Calculate m * (high^2 + high * low + low^2)
-		let term1 = self.m.checked_mul(cubic_term).ok_or(ArithmeticError::Overflow)?;
+		let term1 = if self.m == Coefficient::from_num(0u8) {
+			// if m is 0 the product is 0
+			Ok(self.m)
+		} else {
+			let high_low_mul = high.checked_mul(low).ok_or(ArithmeticError::Overflow)?;
+			let high_square = square(high)?;
+			let low_square = square(low)?;
 
-		let high_plus_low = high.checked_add(low).ok_or(ArithmeticError::Overflow)?;
+			// Factorized cubic term:  (high^2 + high * low + low^2)
+			let cubic_term = high_square
+				.checked_add(high_low_mul)
+				.ok_or(ArithmeticError::Overflow)?
+				.checked_add(low_square)
+				.ok_or(ArithmeticError::Overflow)?;
+
+			self.m.checked_mul(cubic_term).ok_or(ArithmeticError::Overflow)
+		}?;
 
 		// Calculate n * (high + low)
-		let term2 = self.n.checked_mul(high_plus_low).ok_or(ArithmeticError::Overflow)?;
+		let term2 = if self.n == Coefficient::from_num(0u8) {
+			// if n is 0 the product is 0
+			Ok(self.n)
+		} else {
+			let high_plus_low = high.checked_add(low).ok_or(ArithmeticError::Overflow)?;
+			self.n.checked_mul(high_plus_low).ok_or(ArithmeticError::Overflow)
+		}?;
 
 		// Final calculation with factored (high - low)
 		let result = term1
@@ -180,6 +186,9 @@ where
 			.ok_or(ArithmeticError::Overflow)?
 			.checked_add(self.o)
 			.ok_or(ArithmeticError::Overflow)?;
+
+		// Calculate high - low
+		let delta_x = high.checked_sub(low).ok_or(ArithmeticError::Underflow)?;
 
 		result.checked_mul(delta_x).ok_or(ArithmeticError::Overflow)
 	}

--- a/pallets/pallet-bonded-coins/src/curves/square_root.rs
+++ b/pallets/pallet-bonded-coins/src/curves/square_root.rs
@@ -33,12 +33,19 @@
 /// ### Antiderivative
 /// The indefinite integral of the cost function is:
 /// ```text
-/// C(s) = (2/3) * m * s^(3/2) + n * s
+/// C(s) = (2/3) * m * s^(3/2) + n * s = M * s^(3/2) + N * s
 /// ```
 /// Where:
 /// - `s` is the supply of assets,
 /// - `m` is the coefficient for the square root term,
-/// - `n` is the coefficient for the linear term.
+/// - `n` is the coefficient for the constant term,
+/// - `M` is the coefficient for the first (fractional power) term in the
+///   antiderivative,
+/// - `N=n` is the coefficient of the second (linear) term in the
+///   antiderivative.
+///
+/// Coefficients of the antiderivative `N` & `M` are used to parametrize
+/// functions in this module.
 ///
 /// `C(s)` represents the total cost of purchasing or selling assets up to the
 /// current supply `s`. To calculate the incremental cost of a transaction, use
@@ -72,14 +79,19 @@ use crate::{PassiveSupply, Precision};
 /// bonding curve. This struct is used to convert the input parameters to the
 /// correct fixed-point type.
 ///
-/// The input struct assumes that the coefficients are precomputed according to
-/// the integral rules of the square root function./// ### Example
+/// The input struct expects coefficients of terms in the antiderivative of the
+/// square root function, which must be precomputed according to the integral
+/// rules of the square root function.
 ///
-/// For a square root cost function `c(s) = 3 * s^1/2 + 2
+/// ### Example
 ///
-/// which is resulting into the antiderivative
-/// `C(s) = (6 / 3) * s^(1/2) + 2 * s`
-/// the input parameters would be:
+/// For a square root cost function `c(s) = 3 * s^1/2 + 2`
+///
+/// which results in the antiderivative
+/// `C(s) = (2 / 3) * 3 * s^(3/2) + 2 * s = 2s^(3/2) + 2s`
+///
+/// the input parameters `M` & `N` (coefficients of the antiderivative) would
+/// be:
 /// ```rust, ignore
 /// SquareRootParametersInput {
 ///    m: 2,

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -315,6 +315,8 @@ pub mod pallet {
 		Slippage,
 		/// The calculated collateral is zero.
 		ZeroCollateral,
+		/// A pool has to contain at least one bonded currency.
+		ZeroBondedCurrency,
 	}
 
 	#[pallet::call]
@@ -372,6 +374,7 @@ pub mod pallet {
 			let checked_curve = curve.try_into().map_err(|_| Error::<T>::InvalidInput)?;
 
 			let currency_length = currencies.len();
+			ensure!(!currency_length.is_zero(), Error::<T>::ZeroBondedCurrency);
 
 			let currency_ids = T::NextAssetIds::try_get(currency_length.saturated_into())
 				.map_err(|e| e.into())

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -413,7 +413,7 @@ pub mod pallet {
 				balance_to_fixed(max_supply, denomination, Round::Up).map_err(|_| Error::<T>::InvalidInput)?;
 			let max_supply_after_smallest_burn = balance_to_fixed(
 				max_supply
-					.checked_sub(&min_operation_balance)
+					.checked_sub(&min_operation_balance.max(1u128.saturated_into()))
 					.ok_or(Error::<T>::InvalidInput)?,
 				denomination,
 				Round::Up,

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -279,6 +279,12 @@ pub mod pallet {
 			id: T::PoolId,
 			manager: Option<T::AccountId>,
 		},
+		/// The asset managing team of a pool has been reset.
+		TeamChanged {
+			id: T::PoolId,
+			admin: T::AccountId,
+			freezer: T::AccountId,
+		},
 	}
 
 	#[pallet::error]
@@ -501,7 +507,7 @@ pub mod pallet {
 			ensure!(pool_details.is_manager(&who), Error::<T>::NoPermission);
 			ensure!(pool_details.state.is_live(), Error::<T>::PoolNotLive);
 
-			let pool_id_account = pool_id.into();
+			let pool_id_account = pool_id.clone().into();
 
 			let PoolManagingTeam { freezer, admin } = team;
 
@@ -513,7 +519,15 @@ pub mod pallet {
 					pool_id_account.clone(),
 					freezer.clone(),
 				)
-			})
+			})?;
+
+			Self::deposit_event(Event::TeamChanged {
+				id: pool_id,
+				admin,
+				freezer,
+			});
+
+			Ok(())
 		}
 
 		/// Resets the manager of a pool. The new manager will be set to the

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -64,7 +64,7 @@ pub mod pallet {
 				Create as CreateFungibles, Destroy as DestroyFungibles, Inspect as InspectFungibles,
 				Mutate as MutateFungibles,
 			},
-			tokens::{Fortitude, Precision as WithdrawalPrecision, Preservation, Provenance},
+			tokens::{DepositConsequence, Fortitude, Precision as WithdrawalPrecision, Preservation, Provenance},
 			AccountTouch,
 		},
 		Hashable, Parameter,
@@ -1119,8 +1119,7 @@ pub mod pallet {
 
 			if amount.is_zero()
 				|| T::Collaterals::can_deposit(pool_details.collateral.clone(), &who, amount, Provenance::Extant)
-					.into_result()
-					.is_err()
+					== DepositConsequence::BelowMinimum
 			{
 				// Funds are burnt but the collateral received is not sufficient to be deposited
 				// to the account. This is tolerated as otherwise we could have edge cases where

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -536,6 +536,8 @@ pub mod pallet {
 		/// - `Error::<T>::PoolUnknown`: If the pool does not exist.
 		/// - `Error::<T>::NoPermission`: If the caller is not a manager of the
 		///   pool.
+		/// - `Error::<T>::PoolNotLive`: If the pool is not in active or locked
+		///   state.
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::reset_manager())]
 		pub fn reset_manager(
@@ -546,6 +548,7 @@ pub mod pallet {
 			let who = T::DefaultOrigin::ensure_origin(origin)?;
 			Pools::<T>::try_mutate(&pool_id, |maybe_entry| -> DispatchResult {
 				let entry = maybe_entry.as_mut().ok_or(Error::<T>::PoolUnknown)?;
+				ensure!(entry.state.is_live(), Error::<T>::PoolNotLive);
 				ensure!(entry.is_manager(&who), Error::<T>::NoPermission);
 				entry.manager = new_manager.clone();
 

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -327,7 +327,6 @@ pub mod pallet {
 			Copy + ToFixed + AddAssign + BitOrAssign + ShlAssign + TryFrom<U256> + TryInto<U256>,
 		CollateralBalanceOf<T>: Into<U256> + TryFrom<U256>,
 		FungiblesBalanceOf<T>: Into<U256> + TryFrom<U256>,
-		// TODO: make large integer type configurable
 	{
 		/// Creates a new bonded token pool. The pool will be created with the
 		/// given curve, collateral currency, and bonded currencies. The pool
@@ -1430,7 +1429,6 @@ pub mod pallet {
 			ensure!(pool_details.state.is_live(), Error::<T>::PoolNotLive);
 
 			if let Some(caller) = maybe_check_manager {
-				// TODO: should the owner be authorized as well?
 				ensure!(pool_details.is_manager(caller), Error::<T>::NoPermission);
 			}
 
@@ -1503,7 +1501,6 @@ pub mod pallet {
 			);
 
 			if let Some(caller) = maybe_check_manager {
-				// TODO: should this be permissionless if the pool is in refunding state?
 				ensure!(
 					pool_details.is_owner(caller) || pool_details.is_manager(caller),
 					Error::<T>::NoPermission

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -79,6 +79,7 @@ pub mod pallet {
 		BoundedVec, DispatchError, TokenError,
 	};
 	use sp_std::{
+		collections::btree_set::BTreeSet,
 		iter::Iterator,
 		ops::{AddAssign, BitOrAssign, ShlAssign},
 		prelude::*,
@@ -337,7 +338,8 @@ pub mod pallet {
 		/// - `curve`: The curve parameters for the pool.
 		/// - `collateral_id`: The ID of the collateral currency.
 		/// - `currencies`: A bounded vector of token metadata for the bonded
-		///   currencies.
+		///   currencies. Note that no two currencies may use the same name or
+		///   symbol.
 		/// - `denomination`: The denomination for the bonded currencies.
 		/// - `transferable`: A boolean indicating if the bonded currencies are
 		///   transferable.
@@ -346,8 +348,10 @@ pub mod pallet {
 		/// - `DispatchResult`: The result of the dispatch.
 		///
 		/// # Errors
-		/// - `Error::<T>::InvalidInput`: If the denomination is greater than
-		///   the maximum allowed or if the curve input is invalid.
+		/// - `Error::<T>::InvalidInput`: If either
+		///   - the denomination is greater than the maximum allowed
+		///   - the curve input is invalid
+		///   - two currencies use the same name or symbol
 		/// - `Error::<T>::Internal`: If the conversion to `BoundedVec` fails.
 		/// - Other errors depending on the types in the config.
 		#[pallet::call_index(0)]
@@ -407,6 +411,10 @@ pub mod pallet {
 			// currency to it. This should also verify that the currency actually exists.
 			T::Collaterals::touch(collateral_id.clone(), pool_account, &who)?;
 
+			// Enforce unique names and symbols by recording seen values in a set
+			let mut names_seen = BTreeSet::<StringInputOf<T>>::new();
+			let mut symbols_seen = BTreeSet::<StringInputOf<T>>::new();
+
 			currencies.into_iter().zip(currency_ids.iter()).try_for_each(
 				|(token_metadata, asset_id)| -> DispatchResult {
 					let TokenMeta {
@@ -414,6 +422,11 @@ pub mod pallet {
 						name,
 						symbol,
 					} = token_metadata;
+
+					// insert() returns true if the set did not contain the inserted value
+					let name_ok = name.is_empty() || names_seen.insert(name.clone());
+					let symbol_ok = symbol.is_empty() || symbols_seen.insert(symbol.clone());
+					ensure!(name_ok && symbol_ok, Error::<T>::InvalidInput);
 
 					T::Fungibles::create(asset_id.clone(), pool_account.to_owned(), false, min_balance)?;
 

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -570,7 +570,8 @@ pub mod pallet {
 		/// - `origin`: The origin of the call, requiring the caller to be a
 		///   manager of the pool.
 		/// - `pool_id`: The identifier of the pool to be locked.
-		/// - `lock`: The locks to be applied to the pool.
+		/// - `lock`: The locks to be applied to the pool. At least one lock
+		///   flag must be set to `false` for a valid lock.
 		///
 		/// # Returns
 		/// - `DispatchResult`: The result of the dispatch.
@@ -581,10 +582,15 @@ pub mod pallet {
 		///   pool.
 		/// - `Error::<T>::PoolNotLive`: If the pool is not in a live (locked or
 		///   active) state.
+		/// - `Error::<T>::InvalidInput`: If all lock flags are `true` (all
+		///   operations enabled), which would be equivalent to an unlocked
+		///   (active) pool state.
 		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::set_lock())]
 		pub fn set_lock(origin: OriginFor<T>, pool_id: T::PoolId, lock: Locks) -> DispatchResult {
 			let who = T::DefaultOrigin::ensure_origin(origin)?;
+
+			ensure!(lock.any_lock_set(), Error::<T>::InvalidInput);
 
 			Pools::<T>::try_mutate(&pool_id, |pool| -> DispatchResult {
 				let entry = pool.as_mut().ok_or(Error::<T>::PoolUnknown)?;

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -449,18 +449,17 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Changes the managing team of a bonded currency which is issued by
-		/// this pool. The new team will be set to the provided team. The
-		/// currency index is used to select the currency that the team will
-		/// manage. The origin account must be a manager of the pool.
+		/// Changes the managing team of all bonded currencies issued by this
+		/// pool, setting it to the provided `team`. The origin account must be
+		/// a manager of the pool.
 		///
 		/// # Parameters
 		/// - `origin`: The origin of the call, requiring the caller to be a
 		///   manager of the pool.
 		/// - `pool_id`: The identifier of the pool.
 		/// - `team`: The new managing team.
-		/// - `currency_idx`: The index of the currency in the bonded currencies
-		///   vector.
+		/// - `currency_count`: The number of bonded currencies vector linked to
+		///   the pool. Required for weight estimations.
 		///
 		/// # Returns
 		/// - `DispatchResult`: The result of the dispatch.
@@ -469,8 +468,8 @@ pub mod pallet {
 		/// - `Error::<T>::PoolUnknown`: If the pool does not exist.
 		/// - `Error::<T>::NoPermission`: If the caller is not a manager of the
 		///   pool.
-		/// - `Error::<T>::IndexOutOfBounds`: If the currency index is out of
-		///   bounds.
+		/// - `Error::<T>::CurrencyCount`: If the actual number of currencies in
+		///   the pool is larger than `currency_count`.
 		/// - Other errors depending on the types in the config.
 		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::reset_team())]
@@ -478,31 +477,31 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			pool_id: T::PoolId,
 			team: PoolManagingTeam<AccountIdOf<T>>,
-			currency_idx: u32,
+			currency_count: u32,
 		) -> DispatchResult {
 			let who = T::DefaultOrigin::ensure_origin(origin)?;
 
 			let pool_details = Pools::<T>::get(&pool_id).ok_or(Error::<T>::PoolUnknown)?;
 
+			let number_of_currencies = Self::get_currencies_number(&pool_details);
+			ensure!(number_of_currencies <= currency_count, Error::<T>::CurrencyCount);
+
 			ensure!(pool_details.is_manager(&who), Error::<T>::NoPermission);
 			ensure!(pool_details.state.is_live(), Error::<T>::PoolNotLive);
-
-			let asset_id = pool_details
-				.bonded_currencies
-				.get(currency_idx.saturated_into::<usize>())
-				.ok_or(Error::<T>::IndexOutOfBounds)?;
 
 			let pool_id_account = pool_id.into();
 
 			let PoolManagingTeam { freezer, admin } = team;
 
-			T::Fungibles::reset_team(
-				asset_id.to_owned(),
-				pool_id_account.clone(),
-				admin,
-				pool_id_account,
-				freezer,
-			)
+			pool_details.bonded_currencies.into_iter().try_for_each(|asset_id| {
+				T::Fungibles::reset_team(
+					asset_id,
+					pool_id_account.clone(),
+					admin.clone(),
+					pool_id_account.clone(),
+					freezer.clone(),
+				)
+			})
 		}
 
 		/// Resets the manager of a pool. The new manager will be set to the

--- a/pallets/pallet-bonded-coins/src/lib.rs
+++ b/pallets/pallet-bonded-coins/src/lib.rs
@@ -1090,11 +1090,6 @@ pub mod pallet {
 				.checked_add(burnt)
 				.ok_or(ArithmeticError::Overflow)?;
 
-			defensive_assert!(
-				sum_of_issuances >= burnt,
-				"burnt amount exceeds the total supply of all bonded currencies"
-			);
-
 			let amount: CollateralBalanceOf<T> = burnt
 				.checked_mul(total_collateral_issuance.into())
 				// As long as the balance type is half the size of a U256, this won't overflow.

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -249,7 +249,7 @@ pub mod runtime {
 		type Hash = Hash;
 		type Hashing = BlakeTwo256;
 		type Lookup = IdentityLookup<Self::AccountId>;
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 		type Nonce = u64;
 		type OnKilledAccount = ();
 		type OnNewAccount = ();

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -69,7 +69,7 @@ pub mod runtime {
 	use crate::{
 		self as pallet_bonded_coins,
 		traits::NextAssetIds,
-		types::{Locks, PoolStatus},
+		types::{BondedCurrenciesSettings, Locks, PoolStatus},
 		AccountIdOf, Config, DepositBalanceOf, FungiblesAssetIdOf, FungiblesBalanceOf, PoolDetailsOf,
 	};
 
@@ -118,13 +118,16 @@ pub mod runtime {
 		PoolDetailsOf::<Test> {
 			curve,
 			manager,
-			transferable,
 			bonded_currencies,
 			state,
 			collateral,
-			denomination: DEFAULT_BONDED_DENOMINATION,
+			currencies_settings: BondedCurrenciesSettings {
+				allow_reset_team: true,
+				transferable,
+				min_operation_balance,
+				denomination: DEFAULT_BONDED_DENOMINATION,
+			},
 			owner,
-			min_operation_balance,
 			deposit: BondingPallet::calculate_pool_deposit(currencies.len()),
 		}
 	}
@@ -446,7 +449,7 @@ pub mod runtime {
 						pool_details
 							.bonded_currencies
 							.iter()
-							.map(|id| (*id, vec![], vec![], pool_details.denomination))
+							.map(|id| (*id, vec![], vec![], pool_details.currencies_settings.denomination))
 							.collect::<Vec<(u32, Vec<u8>, Vec<u8>, u8)>>()
 					})
 					.chain(

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -126,6 +126,7 @@ pub mod runtime {
 				transferable,
 				min_operation_balance,
 				denomination: DEFAULT_BONDED_DENOMINATION,
+				max_supply: u128::MAX,
 			},
 			owner,
 			deposit: BondingPallet::calculate_pool_deposit(currencies.len()),

--- a/pallets/pallet-bonded-coins/src/mock.rs
+++ b/pallets/pallet-bonded-coins/src/mock.rs
@@ -58,6 +58,7 @@ pub mod runtime {
 		weights::constants::RocksDbWeight,
 	};
 	use frame_system::{EnsureRoot, EnsureSigned};
+	use pallet_assets::FrozenBalance;
 	use sp_core::U256;
 	use sp_runtime::{
 		traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
@@ -69,7 +70,7 @@ pub mod runtime {
 		self as pallet_bonded_coins,
 		traits::NextAssetIds,
 		types::{Locks, PoolStatus},
-		Config, DepositBalanceOf, FungiblesAssetIdOf, PoolDetailsOf,
+		AccountIdOf, Config, DepositBalanceOf, FungiblesAssetIdOf, FungiblesBalanceOf, PoolDetailsOf,
 	};
 
 	pub type Hash = sp_core::H256;
@@ -190,6 +191,28 @@ pub mod runtime {
 		}
 	}
 
+	/// Store freezes for the assets pallet.
+	#[storage_alias]
+	pub type Freezes<Assets: PalletInfoAccess> = StorageDoubleMap<
+		Assets,
+		Blake2_128Concat,
+		FungiblesAssetIdOf<Test>,
+		Blake2_128Concat,
+		AccountIdOf<Test>,
+		FungiblesBalanceOf<Test>,
+		OptionQuery,
+	>;
+
+	pub struct FreezesHook;
+
+	impl FrozenBalance<AssetId, AccountId, Balance> for FreezesHook {
+		fn died(_asset: AssetId, _who: &AccountId) {}
+
+		fn frozen_balance(asset: AssetId, who: &AccountId) -> Option<Balance> {
+			Freezes::<Assets>::get(asset, who)
+		}
+	}
+
 	frame_support::construct_runtime!(
 		pub enum Test
 		{
@@ -279,7 +302,7 @@ pub mod runtime {
 		type Currency = Balances;
 		type Extra = ();
 		type ForceOrigin = EnsureRoot<AccountId>;
-		type Freezer = ();
+		type Freezer = FreezesHook;
 		type MetadataDepositBase = ConstU128<0>;
 		type MetadataDepositPerByte = ConstU128<0>;
 		type RemoveItemsLimit = ConstU32<5>;
@@ -355,6 +378,7 @@ pub mod runtime {
 		//  pool_id, PoolDetails
 		pools: Vec<(AccountId, PoolDetailsOf<Test>)>,
 		collaterals: Vec<AssetId>,
+		freezes: Vec<(AssetId, AccountId, Balance)>,
 	}
 
 	impl ExtBuilder {
@@ -375,6 +399,11 @@ pub mod runtime {
 
 		pub(crate) fn with_bonded_balance(mut self, bonded_balance: Vec<(AssetId, AccountId, Balance)>) -> Self {
 			self.bonded_balance = bonded_balance;
+			self
+		}
+
+		pub(crate) fn with_freezes(mut self, freezes: Vec<(AssetId, AccountId, Balance)>) -> Self {
+			self.freezes = freezes;
 			self
 		}
 
@@ -448,6 +477,10 @@ pub mod runtime {
 				});
 
 				NextAssetId::<BondingPallet>::set(next_asset_id);
+
+				self.freezes.iter().for_each(|(asset_id, account, amount)| {
+					Freezes::<Assets>::set(asset_id, account, Some(*amount));
+				});
 			});
 
 			ext

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -63,6 +63,7 @@ fn burn_first_coin() {
 					allow_reset_team: true,
 					denomination: 0,
 					min_operation_balance: 1,
+					max_supply: u128::MAX,
 				},
 				owner: ACCOUNT_99,
 				deposit: BondingPallet::calculate_pool_deposit(1),

--- a/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/burn_into.rs
@@ -27,7 +27,7 @@ use sp_runtime::{assert_eq_error_rate, bounded_vec, traits::Scale, TokenError};
 
 use crate::{
 	mock::{runtime::*, *},
-	types::{Locks, PoolStatus},
+	types::{BondedCurrenciesSettings, Locks, PoolStatus},
 	AccountIdOf, Error, PoolDetailsOf,
 };
 
@@ -55,13 +55,16 @@ fn burn_first_coin() {
 			PoolDetailsOf::<Test> {
 				curve: get_linear_bonding_curve(),
 				manager: None,
-				transferable: true,
 				bonded_currencies: bounded_vec![DEFAULT_BONDED_CURRENCY_ID],
 				state: PoolStatus::Active,
 				collateral: DEFAULT_COLLATERAL_CURRENCY_ID,
-				denomination: 0,
+				currencies_settings: BondedCurrenciesSettings {
+					transferable: true,
+					allow_reset_team: true,
+					denomination: 0,
+					min_operation_balance: 1,
+				},
 				owner: ACCOUNT_99,
-				min_operation_balance: 1,
 				deposit: BondingPallet::calculate_pool_deposit(1),
 			},
 		)])

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -59,7 +59,8 @@ fn single_currency() {
 					denomination: DEFAULT_BONDED_DENOMINATION,
 					allow_reset_team: true,
 					transferable: true,
-					min_operation_balance: 1
+					min_operation_balance: 1,
+					max_supply: 10_000u128
 				},
 			));
 
@@ -144,7 +145,8 @@ fn multi_currency() {
 					denomination: DEFAULT_BONDED_DENOMINATION,
 					allow_reset_team: true,
 					transferable: true,
-					min_operation_balance: 1
+					min_operation_balance: 1,
+					max_supply: 10_000u128
 				}
 			));
 
@@ -198,7 +200,8 @@ fn multi_currency_with_empty_metadata() {
 					denomination: DEFAULT_BONDED_DENOMINATION,
 					allow_reset_team: true,
 					transferable: true,
-					min_operation_balance: 1
+					min_operation_balance: 1,
+					max_supply: 10_000u128
 				}
 			));
 
@@ -251,7 +254,8 @@ fn can_create_identical_pools() {
 					denomination: DEFAULT_BONDED_DENOMINATION,
 					allow_reset_team: true,
 					transferable: true,
-					min_operation_balance: 1
+					min_operation_balance: 1,
+					max_supply: 10_000u128
 				}
 			));
 
@@ -264,7 +268,8 @@ fn can_create_identical_pools() {
 					denomination: DEFAULT_BONDED_DENOMINATION,
 					allow_reset_team: true,
 					transferable: true,
-					min_operation_balance: 1
+					min_operation_balance: 1,
+					max_supply: 10_000u128
 				}
 			));
 
@@ -321,7 +326,8 @@ fn cannot_reuse_names() {
 						denomination: DEFAULT_BONDED_DENOMINATION,
 						allow_reset_team: true,
 						transferable: true,
-						min_operation_balance: 1
+						min_operation_balance: 1,
+						max_supply: 10_000u128
 					}
 				),
 				Error::<Test>::InvalidInput
@@ -367,7 +373,8 @@ fn cannot_reuse_symbols() {
 						denomination: DEFAULT_BONDED_DENOMINATION,
 						allow_reset_team: true,
 						transferable: true,
-						min_operation_balance: 1
+						min_operation_balance: 1,
+						max_supply: 10_000u128
 					}
 				),
 				Error::<Test>::InvalidInput
@@ -399,7 +406,8 @@ fn fails_if_collateral_not_exists() {
 						denomination: DEFAULT_BONDED_DENOMINATION,
 						allow_reset_team: true,
 						transferable: true,
-						min_operation_balance: 1
+						min_operation_balance: 1,
+						max_supply: 10_000u128
 					}
 				),
 				AssetsPalletErrors::<Test>::Unknown
@@ -434,7 +442,8 @@ fn cannot_create_circular_pool() {
 						denomination: DEFAULT_BONDED_DENOMINATION,
 						allow_reset_team: true,
 						transferable: true,
-						min_operation_balance: 1
+						min_operation_balance: 1,
+						max_supply: 10_000u128
 					}
 				),
 				AssetsPalletErrors::<Test>::Unknown
@@ -470,7 +479,8 @@ fn handles_asset_id_overflow() {
 						denomination: DEFAULT_BONDED_DENOMINATION,
 						allow_reset_team: true,
 						transferable: true,
-						min_operation_balance: 1
+						min_operation_balance: 1,
+						max_supply: 10_000u128
 					}
 				),
 				ArithmeticError::Overflow

--- a/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/create_pool.rs
@@ -28,7 +28,7 @@ use sp_std::ops::Sub;
 
 use crate::{
 	mock::{runtime::*, *},
-	types::{Locks, PoolStatus},
+	types::{BondedCurrenciesSettings, Locks, PoolStatus},
 	AccountIdOf, Error, Event as BondingPalletEvents, Pools, TokenMetaOf,
 };
 
@@ -55,9 +55,12 @@ fn single_currency() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				1,
+				BondedCurrenciesSettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					allow_reset_team: true,
+					transferable: true,
+					min_operation_balance: 1
+				},
 			));
 
 			let pool_id: AccountIdOf<Test> = calculate_pool_id(&[new_asset_id]);
@@ -66,7 +69,7 @@ fn single_currency() {
 
 			assert!(details.is_owner(&ACCOUNT_00));
 			assert!(details.is_manager(&ACCOUNT_00));
-			assert!(details.transferable);
+			assert!(details.currencies_settings.transferable);
 			assert_eq!(
 				details.state,
 				PoolStatus::Locked(Locks {
@@ -74,7 +77,7 @@ fn single_currency() {
 					allow_burn: false,
 				})
 			);
-			assert_eq!(details.denomination, DEFAULT_BONDED_DENOMINATION);
+			assert_eq!(details.currencies_settings.denomination, DEFAULT_BONDED_DENOMINATION);
 			assert_eq!(details.collateral, DEFAULT_COLLATERAL_CURRENCY_ID);
 			assert_eq!(details.bonded_currencies, vec![new_asset_id]);
 
@@ -137,9 +140,12 @@ fn multi_currency() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				1
+				BondedCurrenciesSettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					allow_reset_team: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_eq!(NextAssetId::<BondingPallet>::get(), next_asset_id + 3);
@@ -188,9 +194,12 @@ fn multi_currency_with_empty_metadata() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bonded_tokens,
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				1
+				BondedCurrenciesSettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					allow_reset_team: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_eq!(NextAssetId::<BondingPallet>::get(), next_asset_id + 3);
@@ -238,9 +247,12 @@ fn can_create_identical_pools() {
 				curve.clone(),
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token.clone()],
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				1
+				BondedCurrenciesSettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					allow_reset_team: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_ok!(BondingPallet::create_pool(
@@ -248,9 +260,12 @@ fn can_create_identical_pools() {
 				curve,
 				DEFAULT_COLLATERAL_CURRENCY_ID,
 				bounded_vec![bonded_token],
-				DEFAULT_BONDED_DENOMINATION,
-				true,
-				1
+				BondedCurrenciesSettings {
+					denomination: DEFAULT_BONDED_DENOMINATION,
+					allow_reset_team: true,
+					transferable: true,
+					min_operation_balance: 1
+				}
 			));
 
 			assert_eq!(NextAssetId::<BondingPallet>::get(), next_asset_id + 2);
@@ -302,9 +317,12 @@ fn cannot_reuse_names() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bonded_tokens,
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					1
+					BondedCurrenciesSettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						allow_reset_team: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				Error::<Test>::InvalidInput
 			);
@@ -345,9 +363,12 @@ fn cannot_reuse_symbols() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bonded_tokens,
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					1
+					BondedCurrenciesSettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						allow_reset_team: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				Error::<Test>::InvalidInput
 			);
@@ -374,9 +395,12 @@ fn fails_if_collateral_not_exists() {
 					curve,
 					100,
 					bounded_vec![bonded_token],
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					1
+					BondedCurrenciesSettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						allow_reset_team: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				AssetsPalletErrors::<Test>::Unknown
 			);
@@ -406,9 +430,12 @@ fn cannot_create_circular_pool() {
 					// try specifying the id of the currency to be created as collateral
 					next_asset_id,
 					bounded_vec![bonded_token],
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					1
+					BondedCurrenciesSettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						allow_reset_team: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				AssetsPalletErrors::<Test>::Unknown
 			);
@@ -439,9 +466,12 @@ fn handles_asset_id_overflow() {
 					curve,
 					DEFAULT_COLLATERAL_CURRENCY_ID,
 					bounded_vec![bonded_token; 2],
-					DEFAULT_BONDED_DENOMINATION,
-					true,
-					1
+					BondedCurrenciesSettings {
+						denomination: DEFAULT_BONDED_DENOMINATION,
+						allow_reset_team: true,
+						transferable: true,
+						min_operation_balance: 1
+					}
 				),
 				ArithmeticError::Overflow
 			);

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -51,13 +51,57 @@ fn resets_team() {
 					admin: ACCOUNT_00,
 					freezer: ACCOUNT_01,
 				},
-				0
+				1
 			));
 
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_01));
 			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::issuer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id));
+		})
+}
+
+#[test]
+fn resets_team_for_all() {
+	let currencies = vec![DEFAULT_BONDED_CURRENCY_ID, DEFAULT_BONDED_CURRENCY_ID + 1];
+
+	let pool_details = generate_pool_details(
+		currencies.clone(),
+		get_linear_bonding_curve(),
+		false,
+		Some(PoolStatus::Active),
+		Some(ACCOUNT_00),
+		None,
+		None,
+		None,
+	);
+	let pool_id: AccountIdOf<Test> = calculate_pool_id(&currencies);
+
+	ExtBuilder::default()
+		.with_pools(vec![(pool_id.clone(), pool_details)])
+		.with_collaterals(vec![DEFAULT_COLLATERAL_CURRENCY_ID])
+		.build_and_execute_with_sanity_tests(|| {
+			let manager_origin = RawOrigin::Signed(ACCOUNT_00).into();
+
+			assert_ok!(BondingPallet::reset_team(
+				manager_origin,
+				pool_id.clone(),
+				PoolManagingTeam {
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				},
+				2
+			));
+
+			assert_eq!(Assets::admin(currencies[0]), Some(ACCOUNT_00));
+			assert_eq!(Assets::freezer(currencies[0]), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(currencies[0]), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(currencies[0]), Some(pool_id.clone()));
+
+			assert_eq!(Assets::admin(currencies[1]), Some(ACCOUNT_00));
+			assert_eq!(Assets::freezer(currencies[1]), Some(ACCOUNT_01));
+			assert_eq!(Assets::owner(currencies[1]), Some(pool_id.clone()));
+			assert_eq!(Assets::issuer(currencies[1]), Some(pool_id));
 		})
 }
 
@@ -89,7 +133,7 @@ fn does_not_change_team_when_not_live() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::PoolNotLive
 			);
@@ -130,7 +174,7 @@ fn only_manager_can_change_team() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::NoPermission
 			);
@@ -143,7 +187,7 @@ fn only_manager_can_change_team() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					0
+					1
 				),
 				BondingPalletErrors::<Test>::NoPermission
 			);
@@ -153,7 +197,7 @@ fn only_manager_can_change_team() {
 }
 
 #[test]
-fn handles_currency_idx_out_of_bounds() {
+fn handles_currency_number_incorrect() {
 	let pool_details = generate_pool_details(
 		vec![DEFAULT_BONDED_CURRENCY_ID],
 		get_linear_bonding_curve(),
@@ -180,9 +224,9 @@ fn handles_currency_idx_out_of_bounds() {
 						admin: ACCOUNT_00,
 						freezer: ACCOUNT_00,
 					},
-					2
+					0
 				),
-				BondingPalletErrors::<Test>::IndexOutOfBounds
+				BondingPalletErrors::<Test>::CurrencyCount
 			);
 		})
 }

--- a/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
+++ b/pallets/pallet-bonded-coins/src/tests/transactions/reset_team.rs
@@ -22,7 +22,7 @@ use crate::{
 	mock::{runtime::*, *},
 	traits::ResetTeam,
 	types::{PoolManagingTeam, PoolStatus},
-	AccountIdOf, Error as BondingPalletErrors,
+	AccountIdOf, Error as BondingPalletErrors, Event,
 };
 
 #[test]
@@ -54,6 +54,16 @@ fn resets_team() {
 				},
 				1
 			));
+
+			// Ensure the event is emitted
+			System::assert_has_event(
+				Event::TeamChanged {
+					id: pool_id.clone(),
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				}
+				.into(),
+			);
 
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(ACCOUNT_01));
@@ -106,6 +116,16 @@ fn resets_owner_if_changed() {
 				1
 			));
 
+			// Ensure the event is emitted
+			System::assert_has_event(
+				Event::TeamChanged {
+					id: pool_id.clone(),
+					admin: pool_id.clone(),
+					freezer: pool_id.clone(),
+				}
+				.into(),
+			);
+
 			assert_eq!(Assets::admin(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::freezer(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
 			assert_eq!(Assets::owner(DEFAULT_BONDED_CURRENCY_ID), Some(pool_id.clone()));
@@ -144,6 +164,16 @@ fn resets_team_for_all() {
 				},
 				2
 			));
+
+			// Ensure the event is emitted
+			System::assert_has_event(
+				Event::TeamChanged {
+					id: pool_id.clone(),
+					admin: ACCOUNT_00,
+					freezer: ACCOUNT_01,
+				}
+				.into(),
+			);
 
 			assert_eq!(Assets::admin(currencies[0]), Some(ACCOUNT_00));
 			assert_eq!(Assets::freezer(currencies[0]), Some(ACCOUNT_01));

--- a/pallets/pallet-bonded-coins/src/try_state.rs
+++ b/pallets/pallet-bonded-coins/src/try_state.rs
@@ -18,7 +18,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 			owner,
 			bonded_currencies,
 			state,
-			denomination,
+			currencies_settings,
 			..
 		} = pool_details;
 
@@ -61,7 +61,7 @@ pub(crate) fn do_try_state<T: Config>() -> Result<(), TryRuntimeError> {
 					// The Currency in the fungibles pallet should always match with the
 					// denomination stored in the pool.
 					let currency_denomination = T::Fungibles::decimals(currency_id.clone());
-					assert_eq!(currency_denomination, denomination);
+					assert_eq!(currency_denomination, currencies_settings.denomination);
 
 					// if currency has on-zero supply -> collateral in pool account must be
 					// non-zero.

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -79,15 +79,17 @@ impl<LockType> PoolStatus<LockType> {
 }
 
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub struct BondedCurrenciesSettings {
+pub struct BondedCurrenciesSettings<FungiblesBalance> {
 	/// The minimum amount that can be minted/burnt.
-	pub min_operation_balance: u128,
+	pub min_operation_balance: FungiblesBalance,
 	/// The denomination of all bonded assets the pool.
 	pub denomination: u8,
 	/// Whether asset management team changes are allowed.
 	pub allow_reset_team: bool,
 	/// Whether assets are transferable or not.
 	pub transferable: bool,
+	/// The maximum supply that any currency may have.
+	pub max_supply: FungiblesBalance,
 }
 
 /// Details of a pool.
@@ -111,9 +113,15 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId,
 	pub deposit: DepositBalance,
 }
 
-impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
-	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, BondedCurrenciesSettings>
-where
+impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, FungiblesBalance>
+	PoolDetails<
+		AccountId,
+		ParametrizedCurve,
+		Currencies,
+		BaseCurrencyId,
+		DepositBalance,
+		BondedCurrenciesSettings<FungiblesBalance>,
+	> where
 	AccountId: PartialEq + Clone,
 {
 	#[allow(clippy::too_many_arguments)]
@@ -126,7 +134,8 @@ where
 		transferable: bool,
 		allow_reset_team: bool,
 		denomination: u8,
-		min_operation_balance: u128,
+		min_operation_balance: FungiblesBalance,
+		max_supply: FungiblesBalance,
 		deposit: DepositBalance,
 	) -> Self {
 		Self {
@@ -140,6 +149,7 @@ where
 				allow_reset_team,
 				denomination,
 				min_operation_balance,
+				max_supply,
 			},
 			state: PoolStatus::default(),
 			deposit,

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -78,12 +78,24 @@ impl<LockType> PoolStatus<LockType> {
 	}
 }
 
+#[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
+pub struct BondedCurrenciesSettings {
+	/// The minimum amount that can be minted/burnt.
+	pub min_operation_balance: u128,
+	/// The denomination of all bonded assets the pool.
+	pub denomination: u8,
+	/// Whether asset management team changes are allowed.
+	pub allow_reset_team: bool,
+	/// Whether assets are transferable or not.
+	pub transferable: bool,
+}
+
 /// Details of a pool.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
-pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance> {
+pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, SharedSettings> {
 	/// The owner of the pool.
 	pub owner: AccountId,
-	/// The manager of the pool. If a manager is set, the pool is permissioned.
+	/// The manager of the pool, who can execute privileged transactions.
 	pub manager: Option<AccountId>,
 	/// The curve of the pool.
 	pub curve: ParametrizedCurve,
@@ -93,18 +105,14 @@ pub struct PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId,
 	pub bonded_currencies: Currencies,
 	/// The status of the pool.
 	pub state: PoolStatus<Locks>,
-	/// Whether the pool is transferable or not.
-	pub transferable: bool,
-	/// The denomination of the pool.
-	pub denomination: u8,
-	/// The minimum amount that can be minted/burnt.
-	pub min_operation_balance: u128,
+	/// Shared settings of the currencies in the pool.
+	pub currencies_settings: SharedSettings,
 	/// The deposit to be returned upon destruction of this pool.
 	pub deposit: DepositBalance,
 }
 
 impl<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
-	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance>
+	PoolDetails<AccountId, ParametrizedCurve, Currencies, BaseCurrencyId, DepositBalance, BondedCurrenciesSettings>
 where
 	AccountId: PartialEq + Clone,
 {
@@ -116,6 +124,7 @@ where
 		collateral: BaseCurrencyId,
 		bonded_currencies: Currencies,
 		transferable: bool,
+		allow_reset_team: bool,
 		denomination: u8,
 		min_operation_balance: u128,
 		deposit: DepositBalance,
@@ -126,10 +135,13 @@ where
 			curve,
 			collateral,
 			bonded_currencies,
-			transferable,
+			currencies_settings: BondedCurrenciesSettings {
+				transferable,
+				allow_reset_team,
+				denomination,
+				min_operation_balance,
+			},
 			state: PoolStatus::default(),
-			denomination,
-			min_operation_balance,
 			deposit,
 		}
 	}

--- a/pallets/pallet-bonded-coins/src/types.rs
+++ b/pallets/pallet-bonded-coins/src/types.rs
@@ -25,6 +25,12 @@ pub struct Locks {
 	pub allow_burn: bool,
 }
 
+impl Locks {
+	pub const fn any_lock_set(&self) -> bool {
+		!(self.allow_mint && self.allow_burn)
+	}
+}
+
 /// Status of a pool.
 #[derive(Clone, Encode, Decode, PartialEq, Eq, TypeInfo, MaxEncodedLen, Debug)]
 pub enum PoolStatus<LockType> {

--- a/pallets/pallet-configuration/src/mock.rs
+++ b/pallets/pallet-configuration/src/mock.rs
@@ -79,7 +79,7 @@ pub mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	parameter_types! {

--- a/pallets/pallet-deposit-storage/src/deposit/mock.rs
+++ b/pallets/pallet-deposit-storage/src/deposit/mock.rs
@@ -73,7 +73,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
+++ b/pallets/pallet-deposit-storage/src/fungible/tests/mock.rs
@@ -75,7 +75,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-deposit-storage/src/mock.rs
+++ b/pallets/pallet-deposit-storage/src/mock.rs
@@ -60,7 +60,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-did-lookup/src/mock.rs
+++ b/pallets/pallet-did-lookup/src/mock.rs
@@ -80,7 +80,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-dip-consumer/src/mock.rs
+++ b/pallets/pallet-dip-consumer/src/mock.rs
@@ -54,7 +54,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-dip-provider/src/mock.rs
+++ b/pallets/pallet-dip-provider/src/mock.rs
@@ -54,7 +54,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-inflation/src/mock.rs
+++ b/pallets/pallet-inflation/src/mock.rs
@@ -82,7 +82,7 @@ impl frame_system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-migration/src/mock.rs
+++ b/pallets/pallet-migration/src/mock.rs
@@ -114,7 +114,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 parameter_types! {

--- a/pallets/pallet-relay-store/src/mock.rs
+++ b/pallets/pallet-relay-store/src/mock.rs
@@ -53,7 +53,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = u64;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/pallets/pallet-web3-names/src/mock.rs
+++ b/pallets/pallet-web3-names/src/mock.rs
@@ -114,7 +114,7 @@ pub(crate) mod runtime {
 		type SystemWeightInfo = ();
 		type SS58Prefix = SS58Prefix;
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 		type RuntimeTask = RuntimeTask;
 	}
 

--- a/pallets/parachain-staking/src/mock.rs
+++ b/pallets/parachain-staking/src/mock.rs
@@ -92,7 +92,7 @@ impl frame_system::Config for Test {
 	type BlockLength = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 parameter_types! {
 	pub const ExistentialDeposit: Balance = 1;

--- a/pallets/public-credentials/src/mock.rs
+++ b/pallets/public-credentials/src/mock.rs
@@ -302,7 +302,7 @@ pub(crate) mod runtime {
 		type BlockLength = ();
 		type SS58Prefix = ConstU16<38>;
 		type OnSetCode = ();
-		type MaxConsumers = ConstU32<16>;
+		type MaxConsumers = ConstU32<100>;
 	}
 
 	impl pallet_balances::Config for Test {

--- a/runtime-api/bonded-coins/src/pool_details.rs
+++ b/runtime-api/bonded-coins/src/pool_details.rs
@@ -34,7 +34,7 @@ pub type PoolDetailsOf<AccountId, Balance, AssetId, CollateralAssetId> = PoolDet
 	CurrenciesOf<AssetId, Balance>,
 	CollateralDetails<CollateralAssetId>,
 	Balance,
-	BondedCurrenciesSettings,
+	BondedCurrenciesSettings<Balance>,
 >;
 
 /// Collateral currency details used for the runtime API.

--- a/runtime-api/bonded-coins/src/pool_details.rs
+++ b/runtime-api/bonded-coins/src/pool_details.rs
@@ -16,7 +16,7 @@
 
 // If you feel like getting in touch with us, you can do so at info@botlabs.org
 
-use pallet_bonded_coins::{curves::Curve, PoolDetails};
+use pallet_bonded_coins::{curves::Curve, BondedCurrenciesSettings, PoolDetails};
 use parity_scale_codec::{alloc::string::String, Decode, Encode};
 use scale_info::TypeInfo;
 use sp_std::vec::Vec;
@@ -28,8 +28,14 @@ pub type CurveOf = Curve<String>;
 pub type CurrenciesOf<AssetId, Balance> = Vec<BondedCurrencyDetails<AssetId, Balance>>;
 
 /// Human readable pool details.
-pub type PoolDetailsOf<AccountId, Balance, AssetId, CollateralAssetId> =
-	PoolDetails<AccountId, CurveOf, CurrenciesOf<AssetId, Balance>, CollateralDetails<CollateralAssetId>, Balance>;
+pub type PoolDetailsOf<AccountId, Balance, AssetId, CollateralAssetId> = PoolDetails<
+	AccountId,
+	CurveOf,
+	CurrenciesOf<AssetId, Balance>,
+	CollateralDetails<CollateralAssetId>,
+	Balance,
+	BondedCurrenciesSettings,
+>;
 
 /// Collateral currency details used for the runtime API.
 #[derive(Decode, Encode, TypeInfo)]

--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -162,7 +162,7 @@ pub mod bonded_coins {
 	use super::*;
 
 	/// The size is checked in the runtime by a test.
-	pub const MAX_POOL_BYTE_LENGTH: u32 = 987;
+	pub const MAX_POOL_BYTE_LENGTH: u32 = 1003;
 	pub const BASE_DEPOSIT: Balance = deposit(1, MAX_POOL_BYTE_LENGTH);
 	const ASSET_ID_BYTE_LENGTH: u32 = 8;
 	/// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/assets/src/types.rs#L188

--- a/runtimes/common/src/constants.rs
+++ b/runtimes/common/src/constants.rs
@@ -162,7 +162,7 @@ pub mod bonded_coins {
 	use super::*;
 
 	/// The size is checked in the runtime by a test.
-	pub const MAX_POOL_BYTE_LENGTH: u32 = 986;
+	pub const MAX_POOL_BYTE_LENGTH: u32 = 987;
 	pub const BASE_DEPOSIT: Balance = deposit(1, MAX_POOL_BYTE_LENGTH);
 	const ASSET_ID_BYTE_LENGTH: u32 = 8;
 	/// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/assets/src/types.rs#L188

--- a/runtimes/common/src/dip/deposit/mock.rs
+++ b/runtimes/common/src/dip/deposit/mock.rs
@@ -52,7 +52,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = Hash;
 	type Hashing = Hasher;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = Nonce;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/runtimes/common/src/dip/mock.rs
+++ b/runtimes/common/src/dip/mock.rs
@@ -74,7 +74,7 @@ impl frame_system::Config for TestRuntime {
 	type Hash = Hash;
 	type Hashing = Hasher;
 	type Lookup = IdentityLookup<Self::AccountId>;
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 	type Nonce = Nonce;
 	type OnKilledAccount = ();
 	type OnNewAccount = ();

--- a/runtimes/common/src/fees.rs
+++ b/runtimes/common/src/fees.rs
@@ -219,7 +219,7 @@ mod tests {
 		type SystemWeightInfo = ();
 		type SS58Prefix = ();
 		type OnSetCode = ();
-		type MaxConsumers = frame_support::traits::ConstU32<16>;
+		type MaxConsumers = frame_support::traits::ConstU32<100>;
 	}
 
 	impl pallet_balances::Config for Test {

--- a/runtimes/kestrel/src/lib.rs
+++ b/runtimes/kestrel/src/lib.rs
@@ -198,7 +198,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = SS58Prefix;
 	/// The set code logic, just the default since we're not a parachain.
 	type OnSetCode = ();
-	type MaxConsumers = ConstU32<16>;
+	type MaxConsumers = ConstU32<100>;
 }
 
 /// Maximum number of nominators per validator.

--- a/runtimes/peregrine/src/runtime_apis.rs
+++ b/runtimes/peregrine/src/runtime_apis.rs
@@ -521,7 +521,8 @@ impl_runtime_apis! {
 			high: Balance,
 		) -> Result<Balance, BondedCurrencyError> {
 			let pool = Pools::<Runtime>::get(pool_id).ok_or(BondedCurrencyError::PoolNotFound)?;
-			let PoolDetailsOf::<Runtime> { curve, bonded_currencies, denomination, collateral, .. } = pool;
+			let PoolDetailsOf::<Runtime> { curve, bonded_currencies, currencies_settings, collateral, .. } = pool;
+			let denomination = currencies_settings.denomination;
 			let currency_id = bonded_currencies.get(currency_idx.saturated_into::<usize>()).ok_or(BondedCurrencyError::CurrencyNotFound)?;
 
 			let collateral_denomination = NativeAndForeignAssets::decimals(collateral);
@@ -578,15 +579,13 @@ impl_runtime_apis! {
 			let pool = Pools::<Runtime>::get(pool_id).ok_or(BondedCurrencyError::PoolNotFound)?;
 			let PoolDetailsOf::<Runtime> {
 				curve,
+				currencies_settings,
 				bonded_currencies,
 				owner,
 				collateral,
-				denomination,
 				deposit,
-				min_operation_balance,
 				manager,
 				state,
-				transferable,
 			} = pool;
 
 			let currencies = bonded_currencies.iter().map(|currency_id| -> Result<BondedCurrencyDetails<BondedAssetId, Balance>, BondedCurrencyError> {
@@ -629,12 +628,10 @@ impl_runtime_apis! {
 				curve: fmt_curve,
 				collateral: collateral_details,
 				owner,
-				denomination,
 				deposit,
-				min_operation_balance,
 				manager,
 				state,
-				transferable,
+				currencies_settings
 			})
 		}
 

--- a/runtimes/peregrine/src/system/mod.rs
+++ b/runtimes/peregrine/src/system/mod.rs
@@ -93,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<SS_58_PREFIX>;
 	/// The set code logic
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 impl pallet_timestamp::Config for Runtime {

--- a/runtimes/spiritnet/src/system/mod.rs
+++ b/runtimes/spiritnet/src/system/mod.rs
@@ -93,7 +93,7 @@ impl frame_system::Config for Runtime {
 	type SS58Prefix = ConstU16<SS_58_PREFIX>;
 	/// The set code logic
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Runtime>;
-	type MaxConsumers = frame_support::traits::ConstU32<16>;
+	type MaxConsumers = frame_support::traits::ConstU32<100>;
 }
 
 impl pallet_timestamp::Config for Runtime {


### PR DESCRIPTION
## fixes https://github.com/KILTprotocol/ticket/issues/3796

POC for restricting curve parameters on pool creation. Makes a dry run to check that a mint to max supply would not overflow.

## Checklist:

- [ ] I have verified that the code works
  - [ ] No panics! (checked arithmetic ops, no indexing `array[3]` use `get(3)`, ...)
- [ ] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
    * Either PR or Ticket to update [the Docs](https://github.com/KILTprotocol/docs)
    * Link the PR/Ticket here
